### PR TITLE
Add Groq API fallback for voice input

### DIFF
--- a/java/src/org/futo/inputmethod/latin/uix/VoiceInputSettingKeys.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/VoiceInputSettingKeys.kt
@@ -2,6 +2,7 @@ package org.futo.inputmethod.latin.uix
 
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 
 val ENABLE_SOUND = SettingsKey(
@@ -62,4 +63,13 @@ val MULTILINGUAL_MODEL_INDEX = SettingsKey(
 val LANGUAGE_TOGGLES = SettingsKey(
     key = stringSetPreferencesKey("enabled_languages"),
     default = setOf()
+)
+val USE_GROQ_API = SettingsKey(
+    key = booleanPreferencesKey("use_groq_api"),
+    default = false
+)
+
+val GROQ_API_KEY = SettingsKey(
+    key = stringPreferencesKey("groq_api_key"),
+    default = ""
 )

--- a/java/src/org/futo/inputmethod/latin/uix/actions/VoiceInputAction.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/VoiceInputAction.kt
@@ -37,6 +37,8 @@ import org.futo.inputmethod.latin.uix.PersistentActionState
 import org.futo.inputmethod.latin.uix.ResourceHelper
 import org.futo.inputmethod.latin.uix.USE_VAD_AUTOSTOP
 import org.futo.inputmethod.latin.uix.VERBOSE_PROGRESS
+import org.futo.inputmethod.latin.uix.GROQ_API_KEY
+import org.futo.inputmethod.latin.uix.USE_GROQ_API
 import org.futo.inputmethod.latin.uix.getSetting
 import org.futo.inputmethod.latin.uix.setSetting
 import org.futo.inputmethod.latin.xlm.UserDictionaryObserver
@@ -110,6 +112,8 @@ private class VoiceInputActionWindow(
         val requestAudioFocus = context.getSetting(AUDIO_FOCUS)
         val canExpandSpace = context.getSetting(CAN_EXPAND_SPACE)
         val useVAD = context.getSetting(USE_VAD_AUTOSTOP)
+        val useGroq = context.getSetting(USE_GROQ_API)
+        val groqKey = context.getSetting(GROQ_API_KEY)
 
         val primaryModel = model
         val languageSpecificModels = mutableMapOf<Language, ModelLoader>()
@@ -135,7 +139,9 @@ private class VoiceInputActionWindow(
                 requestAudioFocus = requestAudioFocus,
                 canExpandSpace = canExpandSpace,
                 useVADAutoStop = useVAD
-            )
+            ),
+            useGroqApi = useGroq,
+            groqApiKey = groqKey
         )
     }
 

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/VoiceInput.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/VoiceInput.kt
@@ -17,6 +17,13 @@ import org.futo.inputmethod.latin.uix.PREFER_BLUETOOTH
 import org.futo.inputmethod.latin.uix.USE_SYSTEM_VOICE_INPUT
 import org.futo.inputmethod.latin.uix.USE_VAD_AUTOSTOP
 import org.futo.inputmethod.latin.uix.VERBOSE_PROGRESS
+import org.futo.inputmethod.latin.uix.GROQ_API_KEY
+import org.futo.inputmethod.latin.uix.USE_GROQ_API
+import androidx.lifecycle.lifecycleScope
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import org.futo.voiceinput.shared.groq.GroqClient
+import org.futo.inputmethod.latin.uix.settings.navigateToError
+import org.futo.inputmethod.latin.uix.settings.navigateToInfo
 import org.futo.inputmethod.latin.uix.settings.NavigationItem
 import org.futo.inputmethod.latin.uix.settings.NavigationItemStyle
 import org.futo.inputmethod.latin.uix.settings.ScreenTitle
@@ -89,6 +96,32 @@ fun VoiceInputScreen(navController: NavHostController = rememberNavController())
                 title = "Auto-stop on silence",
                 subtitle = "Automatically stop when silence is detected. You may need to manually stop regardless if there's too much background noise. Please also enable long-form voice input to prevent stopping after 30s.",
                 setting = USE_VAD_AUTOSTOP
+            )
+
+            SettingToggleDataStore(
+                title = "Use Groq API",
+                subtitle = "Send audio to Groq when online",
+                setting = USE_GROQ_API
+            )
+
+            SettingTextField(
+                title = "Groq API Key",
+                placeholder = "sk-...",
+                field = GROQ_API_KEY
+            )
+
+            NavigationItem(
+                title = "Test Groq API",
+                style = NavigationItemStyle.Misc,
+                navigate = {
+                    val owner = LocalLifecycleOwner.current
+                    owner.lifecycleScope.launch {
+                        val key = context.getSettingBlocking(GROQ_API_KEY)
+                        val ok = GroqClient.test(key)
+                        if(ok) navController.navigateToInfo("Groq", "Connection successful")
+                        else navController.navigateToError("Groq", "Connection failed")
+                    }
+                }
             )
 
             NavigationItem(

--- a/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/AudioRecognizer.kt
+++ b/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/AudioRecognizer.kt
@@ -29,6 +29,9 @@ import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.selects.select
 import org.futo.voiceinput.shared.ggml.InferenceCancelledException
 import org.futo.voiceinput.shared.types.AudioRecognizerListener
 import org.futo.voiceinput.shared.types.InferenceState
@@ -42,6 +45,7 @@ import org.futo.voiceinput.shared.whisper.ModelManager
 import org.futo.voiceinput.shared.whisper.MultiModelRunConfiguration
 import org.futo.voiceinput.shared.whisper.MultiModelRunner
 import org.futo.voiceinput.shared.whisper.isBlankResult
+import org.futo.voiceinput.shared.groq.GroqClient
 import java.nio.FloatBuffer
 import java.nio.ShortBuffer
 import kotlin.math.min
@@ -86,7 +90,9 @@ data class RecordingSettings(
 data class AudioRecognizerSettings(
     val modelRunConfiguration: MultiModelRunConfiguration,
     val decodingConfiguration: DecodingConfiguration,
-    val recordingConfiguration: RecordingSettings
+    val recordingConfiguration: RecordingSettings,
+    val useGroqApi: Boolean,
+    val groqApiKey: String
 )
 
 class ModelDoesNotExistException(val models: List<ModelLoader>) : Throwable()
@@ -539,27 +545,44 @@ class AudioRecognizer(
         val floatArray = floatSamples.array().sliceArray(0 until floatSamples.position())
 
         yield()
-        val outputText = try {
-             modelRunner.run(
-                floatArray,
-                settings.modelRunConfiguration,
-                settings.decodingConfiguration,
-                runnerCallback
-            ).trim()
-        }catch(e: InferenceCancelledException) {
-            yield()
-            return
-        }
+        coroutineScope {
+            val localJob = async(Dispatchers.Default) {
+                try {
+                    modelRunner.run(
+                        floatArray,
+                        settings.modelRunConfiguration,
+                        settings.decodingConfiguration,
+                        runnerCallback
+                    ).trim()
+                } catch(e: InferenceCancelledException) {
+                    null
+                }
+            }
 
-        val text = when {
-            isBlankResult(outputText) -> ""
-            else -> outputText
-        }
+            val remoteJob = if(settings.useGroqApi && settings.groqApiKey.isNotBlank()) {
+                async(Dispatchers.IO) {
+                    GroqClient.transcribe(floatArray, GroqClient.Config(settings.groqApiKey))
+                }
+            } else null
 
-        yield()
-        lifecycleScope.launch {
+            val resultPair = select<Pair<String?, Boolean>> {
+                localJob.onAwait { Pair(it, true) }
+                remoteJob?.onAwait { Pair(it, false) }
+            }
+
+            val text = if(!resultPair.second && resultPair.first != null && resultPair.first.isNotBlank()) {
+                localJob.cancel()
+                resultPair.first
+            } else {
+                if(resultPair.second) {
+                    remoteJob?.cancel()
+                    resultPair.first ?: remoteJob?.await()
+                } else {
+                    localJob.await()
+                }
+            } ?: ""
+
             withContext(Dispatchers.Main) {
-                yield()
                 listener.finished(text)
             }
         }

--- a/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/RecognizerView.kt
+++ b/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/RecognizerView.kt
@@ -25,7 +25,9 @@ data class RecognizerViewSettings(
 
     val modelRunConfiguration: MultiModelRunConfiguration,
     val decodingConfiguration: DecodingConfiguration,
-    val recordingConfiguration: RecordingSettings
+    val recordingConfiguration: RecordingSettings,
+    val useGroqApi: Boolean,
+    val groqApiKey: String
 )
 
 private val VerboseAnnotations = hashMapOf(
@@ -205,7 +207,9 @@ class RecognizerView(
         settings = AudioRecognizerSettings(
             modelRunConfiguration = settings.modelRunConfiguration,
             decodingConfiguration = settings.decodingConfiguration,
-            recordingConfiguration = settings.recordingConfiguration
+            recordingConfiguration = settings.recordingConfiguration,
+            useGroqApi = settings.useGroqApi,
+            groqApiKey = settings.groqApiKey
         )
     )
 

--- a/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/groq/GroqClient.kt
+++ b/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/groq/GroqClient.kt
@@ -1,0 +1,79 @@
+package org.futo.voiceinput.shared.groq
+
+import org.json.JSONObject
+import java.io.DataOutputStream
+import java.net.HttpURLConnection
+import java.net.URL
+
+object GroqClient {
+    data class Config(val apiKey: String)
+
+    fun pcm16ToWav(pcmData: ByteArray): ByteArray {
+        val sampleRate = 16000
+        val byteRate = 16 * sampleRate / 8
+        val dataLength = pcmData.size
+        val chunkSize = 36 + dataLength
+        val header = ByteArray(44)
+        header[0] = 'R'.code.toByte(); header[1] = 'I'.code.toByte(); header[2] = 'F'.code.toByte(); header[3] = 'F'.code.toByte()
+        header[4] = (chunkSize and 0xff).toByte(); header[5] = (chunkSize shr 8).toByte(); header[6] = (chunkSize shr 16).toByte(); header[7] = (chunkSize shr 24).toByte()
+        header[8] = 'W'.code.toByte(); header[9] = 'A'.code.toByte(); header[10] = 'V'.code.toByte(); header[11] = 'E'.code.toByte()
+        header[12] = 'f'.code.toByte(); header[13] = 'm'.code.toByte(); header[14] = 't'.code.toByte(); header[15] = ' '.code.toByte()
+        header[16] = 16; header[20] = 1; header[22] = 1; header[24] = (sampleRate and 0xff).toByte(); header[25] = (sampleRate shr 8).toByte(); header[26] = (sampleRate shr 16).toByte(); header[27] = (sampleRate shr 24).toByte()
+        header[28] = (byteRate and 0xff).toByte(); header[29] = (byteRate shr 8).toByte(); header[30] = (byteRate shr 16).toByte(); header[31] = (byteRate shr 24).toByte(); header[32] = 2; header[34] = 16
+        header[36] = 'd'.code.toByte(); header[37] = 'a'.code.toByte(); header[38] = 't'.code.toByte(); header[39] = 'a'.code.toByte();
+        header[40] = (dataLength and 0xff).toByte(); header[41] = (dataLength shr 8).toByte(); header[42] = (dataLength shr 16).toByte(); header[43] = (dataLength shr 24).toByte()
+        return header + pcmData
+    }
+
+    fun floatArrayToPCM(samples: FloatArray): ByteArray {
+        val out = ByteArray(samples.size * 2)
+        var i = 0
+        for (f in samples) {
+            val v = (f.coerceIn(-1f, 1f) * Short.MAX_VALUE).toInt().toShort()
+            out[i] = (v.toInt() and 0xff).toByte(); out[i+1] = ((v.toInt() shr 8) and 0xff).toByte(); i += 2
+        }
+        return out
+    }
+
+    fun transcribe(samples: FloatArray, config: Config): String? {
+        val pcm = floatArrayToPCM(samples)
+        val wav = pcm16ToWav(pcm)
+        val boundary = "----groq${System.currentTimeMillis()}"
+        val url = URL("https://api.groq.com/openai/v1/audio/transcriptions")
+        val conn = url.openConnection() as HttpURLConnection
+        conn.requestMethod = "POST"
+        conn.setRequestProperty("Authorization", "Bearer ${config.apiKey}")
+        conn.setRequestProperty("Content-Type", "multipart/form-data; boundary=$boundary")
+        conn.doOutput = true
+        DataOutputStream(conn.outputStream).use { out ->
+            out.writeBytes("--$boundary\r\n")
+            out.writeBytes("Content-Disposition: form-data; name=\"model\"\r\n\r\nwhisper-large-v3\r\n")
+            out.writeBytes("--$boundary\r\n")
+            out.writeBytes("Content-Disposition: form-data; name=\"file\"; filename=\"audio.wav\"\r\n")
+            out.writeBytes("Content-Type: audio/wav\r\n\r\n")
+            out.write(wav)
+            out.writeBytes("\r\n--$boundary--\r\n")
+        }
+        return try {
+            val text = conn.inputStream.bufferedReader().readText()
+            val json = JSONObject(text)
+            json.optString("text", null)
+        } catch(e: Exception) {
+            null
+        } finally {
+            conn.disconnect()
+        }
+    }
+
+    fun test(apiKey: String): Boolean {
+        return try {
+            val url = URL("https://api.groq.com/openai/v1/models")
+            val conn = url.openConnection() as HttpURLConnection
+            conn.setRequestProperty("Authorization", "Bearer $apiKey")
+            conn.inputStream.close()
+            conn.responseCode == 200
+        } catch(e: Exception) {
+            false
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- expose Groq API key and toggle in voice input settings
- add GroqClient for network transcription
- run local whisper model and Groq request concurrently
- include quick API test button in settings

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68660a5097d48327b2a00c14f5345c9a