### PR TITLE
Update voice input with Groq fallback

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: Build APK
+
+on:
+  push:
+    branches: ["**"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Build APK
+        run: ./gradlew assembleUnstableDebug
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: keyboard-apk
+          path: build/outputs/apk/unstable/debug/*.apk
+

--- a/build.gradle
+++ b/build.gradle
@@ -185,6 +185,7 @@ android {
 
             buildConfigField "String", "PAYMENT_URL", "\"https://pay.futo.org/api/PaymentPortal?product=voiceinput&success=futo-keyboard%3a%2f%2flicense%2factivate\""
             buildConfigField "String", "PAYMENT_PRICE", "\"~\$6.99\""
+            buildConfigField "String", "GROQ_API_KEY", "\"\""
         }
 
         stable {
@@ -195,6 +196,7 @@ android {
 
             buildConfigField "String", "PAYMENT_URL", "\"https://pay.futo.org/api/PaymentPortal?product=voiceinput&success=futo-keyboard%3a%2f%2flicense%2factivate\""
             buildConfigField "String", "PAYMENT_PRICE", "\"~\$6.99\""
+            buildConfigField "String", "GROQ_API_KEY", "\"\""
         }
 
         playstore {
@@ -208,6 +210,7 @@ android {
 
             buildConfigField "String", "PAYMENT_URL", "\"https://play.google.com/store/apps/details?id=org.futo.keyboardpayment\""
             buildConfigField "String", "PAYMENT_PRICE", "\"~\$11.99\""
+            buildConfigField "String", "GROQ_API_KEY", "\"\""
         }
     }
 

--- a/java/res/values/strings-uix.xml
+++ b/java/res/values/strings-uix.xml
@@ -492,6 +492,11 @@
     <string name="voice_input_settings_autostop_vad_subtitle">Automatically stop when silence is detected. You may need to manually stop regardless if there\'s too much background noise.</string>
     <string name="voice_input_settings_change_models">Models</string>
     <string name="voice_input_settings_change_models_subtitle">To change the models, visit Languages &amp; Models menu</string>
+    <string name="voice_input_settings_use_groq_api">Use Groq cloud whisper</string>
+    <string name="voice_input_settings_use_groq_api_subtitle">Send audio to Groq API when online</string>
+    <string name="voice_input_settings_test_groq_api">Test Groq voice input</string>
+    <string name="voice_input_settings_test_groq_api_success">Groq API reachable</string>
+    <string name="voice_input_settings_test_groq_api_failure">Groq API test failed</string>
 
     <!-- Prediction menu -->
     <string name="prediction_settings_title">Text Prediction</string>

--- a/java/src/org/futo/inputmethod/latin/uix/VoiceInputSettingKeys.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/VoiceInputSettingKeys.kt
@@ -63,3 +63,8 @@ val LANGUAGE_TOGGLES = SettingsKey(
     key = stringSetPreferencesKey("enabled_languages"),
     default = setOf()
 )
+
+val USE_GROQ_API = SettingsKey(
+    key = booleanPreferencesKey("use_groq_api"),
+    default = false
+)

--- a/java/src/org/futo/inputmethod/latin/uix/actions/VoiceInputAction.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/VoiceInputAction.kt
@@ -35,6 +35,7 @@ import org.futo.inputmethod.latin.uix.PREFER_BLUETOOTH
 import org.futo.inputmethod.latin.uix.PersistentActionState
 import org.futo.inputmethod.latin.uix.ResourceHelper
 import org.futo.inputmethod.latin.uix.USE_VAD_AUTOSTOP
+import org.futo.inputmethod.latin.uix.USE_GROQ_API
 import org.futo.inputmethod.latin.uix.VERBOSE_PROGRESS
 import org.futo.inputmethod.latin.uix.getSetting
 import org.futo.inputmethod.latin.uix.setSetting
@@ -121,6 +122,7 @@ private class VoiceInputActionWindow(
         val requestAudioFocus = context.getSetting(AUDIO_FOCUS)
         val canExpandSpace = context.getSetting(CAN_EXPAND_SPACE)
         val useVAD = context.getSetting(USE_VAD_AUTOSTOP)
+        val useGroq = context.getSetting(USE_GROQ_API)
 
         val primaryModel = model
         val languageSpecificModels = mutableMapOf<Language, ModelLoader>()
@@ -146,7 +148,8 @@ private class VoiceInputActionWindow(
                 requestAudioFocus = requestAudioFocus,
                 canExpandSpace = canExpandSpace,
                 useVADAutoStop = useVAD
-            )
+            ),
+            useGroqApi = useGroq
         )
     }
 

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/VoiceInput.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/VoiceInput.kt
@@ -1,7 +1,13 @@
 package org.futo.inputmethod.latin.uix.settings.pages
 
 import android.content.Intent
+import android.widget.Toast
 import androidx.compose.runtime.Composable
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.futo.inputmethod.latin.BuildConfig
 import org.futo.inputmethod.latin.R
 import org.futo.inputmethod.latin.uix.AUDIO_FOCUS
 import org.futo.inputmethod.latin.uix.CAN_EXPAND_SPACE
@@ -10,12 +16,14 @@ import org.futo.inputmethod.latin.uix.ENABLE_SOUND
 import org.futo.inputmethod.latin.uix.PREFER_BLUETOOTH
 import org.futo.inputmethod.latin.uix.USE_SYSTEM_VOICE_INPUT
 import org.futo.inputmethod.latin.uix.USE_VAD_AUTOSTOP
+import org.futo.inputmethod.latin.uix.USE_GROQ_API
 import org.futo.inputmethod.latin.uix.VERBOSE_PROGRESS
 import org.futo.inputmethod.latin.uix.settings.NavigationItemStyle
 import org.futo.inputmethod.latin.uix.settings.UserSettingsMenu
 import org.futo.inputmethod.latin.uix.settings.useDataStoreValue
 import org.futo.inputmethod.latin.uix.settings.userSettingNavigationItem
 import org.futo.inputmethod.latin.uix.settings.userSettingToggleDataStore
+import org.futo.voiceinput.shared.whisper.GroqClient
 
 private val visibilityCheckNotSystemVoiceInput = @Composable {
     useDataStoreValue(USE_SYSTEM_VOICE_INPUT) == false
@@ -71,6 +79,31 @@ val VoiceInputMenu = UserSettingsMenu(
             title = R.string.voice_input_settings_autostop_vad,
             subtitle = R.string.voice_input_settings_autostop_vad_subtitle,
             setting = USE_VAD_AUTOSTOP
+        ).copy(visibilityCheck = visibilityCheckNotSystemVoiceInput),
+
+        userSettingToggleDataStore(
+            title = R.string.voice_input_settings_use_groq_api,
+            subtitle = R.string.voice_input_settings_use_groq_api_subtitle,
+            setting = USE_GROQ_API
+        ).copy(visibilityCheck = visibilityCheckNotSystemVoiceInput),
+
+        userSettingNavigationItem(
+            title = R.string.voice_input_settings_test_groq_api,
+            style = NavigationItemStyle.MiscNoArrow,
+            navigate = { nav ->
+                val ctx = nav.context
+                GlobalScope.launch(Dispatchers.IO) {
+                    val ok = GroqClient.testConnection(BuildConfig.GROQ_API_KEY)
+                    withContext(Dispatchers.Main) {
+                        val msg = if(ok) {
+                            ctx.getString(R.string.voice_input_settings_test_groq_api_success)
+                        } else {
+                            ctx.getString(R.string.voice_input_settings_test_groq_api_failure)
+                        }
+                        Toast.makeText(ctx, msg, Toast.LENGTH_SHORT).show()
+                    }
+                }
+            }
         ).copy(visibilityCheck = visibilityCheckNotSystemVoiceInput),
 
         userSettingNavigationItem(

--- a/voiceinput-shared/build.gradle
+++ b/voiceinput-shared/build.gradle
@@ -46,6 +46,7 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
+        buildConfigField "String", "GROQ_API_KEY", "\"\""
     }
 
     buildTypes {

--- a/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/AudioRecognizer.kt
+++ b/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/AudioRecognizer.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.async
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
 import org.futo.voiceinput.shared.ggml.InferenceCancelledException
@@ -41,7 +42,9 @@ import org.futo.voiceinput.shared.whisper.DecodingConfiguration
 import org.futo.voiceinput.shared.whisper.ModelManager
 import org.futo.voiceinput.shared.whisper.MultiModelRunConfiguration
 import org.futo.voiceinput.shared.whisper.MultiModelRunner
+import org.futo.voiceinput.shared.whisper.GroqClient
 import org.futo.voiceinput.shared.whisper.isBlankResult
+import org.futo.voiceinput.shared.BuildConfig
 import java.nio.FloatBuffer
 import java.nio.ShortBuffer
 import kotlin.math.min
@@ -86,7 +89,8 @@ data class RecordingSettings(
 data class AudioRecognizerSettings(
     val modelRunConfiguration: MultiModelRunConfiguration,
     val decodingConfiguration: DecodingConfiguration,
-    val recordingConfiguration: RecordingSettings
+    val recordingConfiguration: RecordingSettings,
+    val useGroqApi: Boolean
 )
 
 class ModelDoesNotExistException(val models: List<ModelLoader>) : Throwable()
@@ -102,6 +106,8 @@ class AudioRecognizer(
     private var recorder: AudioRecord? = null
 
     private val modelRunner = MultiModelRunner(modelManager)
+
+    private val useGroq = settings.useGroqApi
 
     private val canExpandSpace = settings.recordingConfiguration.canExpandSpace
     private val useVAD = settings.recordingConfiguration.useVADAutoStop
@@ -541,22 +547,37 @@ class AudioRecognizer(
         val floatArray = floatSamples.array().sliceArray(0 until floatSamples.position())
 
         yield()
-        val outputText = try {
-             modelRunner.run(
-                floatArray,
-                settings.modelRunConfiguration,
-                settings.decodingConfiguration,
-                runnerCallback
-            ).trim()
-        }catch(e: InferenceCancelledException) {
-            yield()
-            return
+
+        val localJob = lifecycleScope.async(Dispatchers.Default) {
+            try {
+                modelRunner.run(
+                    floatArray,
+                    settings.modelRunConfiguration,
+                    settings.decodingConfiguration,
+                    runnerCallback
+                ).trim()
+            } catch(e: InferenceCancelledException) {
+                null
+            }
         }
 
-        val text = when {
-            isBlankResult(outputText) -> ""
-            else -> outputText
-        }
+        val remoteJob = if(useGroq && BuildConfig.GROQ_API_KEY.isNotBlank()) {
+            lifecycleScope.async(Dispatchers.IO) {
+                try {
+                    GroqClient.transcribe(
+                        floatArray,
+                        settings.decodingConfiguration.languages.firstOrNull()?.toWhisperString(),
+                        BuildConfig.GROQ_API_KEY
+                    )
+                } catch(_: Exception) {
+                    null
+                }
+            }
+        } else null
+
+        val outputText = remoteJob?.await() ?: localJob.await() ?: ""
+
+        val text = if (isBlankResult(outputText)) "" else outputText
 
         yield()
         lifecycleScope.launch {

--- a/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/RecognizerView.kt
+++ b/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/RecognizerView.kt
@@ -25,7 +25,8 @@ data class RecognizerViewSettings(
 
     val modelRunConfiguration: MultiModelRunConfiguration,
     val decodingConfiguration: DecodingConfiguration,
-    val recordingConfiguration: RecordingSettings
+    val recordingConfiguration: RecordingSettings,
+    val useGroqApi: Boolean
 )
 
 private val VerboseAnnotations = hashMapOf(
@@ -205,7 +206,8 @@ class RecognizerView(
         settings = AudioRecognizerSettings(
             modelRunConfiguration = settings.modelRunConfiguration,
             decodingConfiguration = settings.decodingConfiguration,
-            recordingConfiguration = settings.recordingConfiguration
+            recordingConfiguration = settings.recordingConfiguration,
+            useGroqApi = settings.useGroqApi
         )
     )
 

--- a/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/whisper/GroqClient.kt
+++ b/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/whisper/GroqClient.kt
@@ -1,0 +1,67 @@
+package org.futo.voiceinput.shared.whisper
+
+import android.util.Base64
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import org.futo.inputmethod.latin.network.BlockingHttpClient
+import org.futo.inputmethod.latin.network.HttpUrlConnectionBuilder
+import java.io.ByteArrayOutputStream
+
+@Serializable
+private data class GroqRequest(
+    val model: String,
+    val language: String? = null,
+    val audio: String
+)
+
+@Serializable
+private data class GroqResponse(val text: String)
+
+object GroqClient {
+    suspend fun transcribe(samples: FloatArray, language: String?, apiKey: String): String = withContext(Dispatchers.IO) {
+        val pcm = ShortArray(samples.size) { (samples[it] * Short.MAX_VALUE).toInt().toShort() }
+        val bytes = ByteArrayOutputStream(pcm.size * 2)
+        pcm.forEach {
+            bytes.write(it.toInt() and 0xFF)
+            bytes.write((it.toInt() shr 8) and 0xFF)
+        }
+        val payload = GroqRequest(
+            model = "whisper-large",
+            language = language,
+            audio = Base64.encodeToString(bytes.toByteArray(), Base64.NO_WRAP)
+        )
+        val json = Json.encodeToString(payload).toByteArray()
+
+        val conn = HttpUrlConnectionBuilder()
+            .setUrl("https://api.groq.com/openai/v1/audio/transcriptions")
+            .setMode(HttpUrlConnectionBuilder.MODE_BI_DIRECTIONAL)
+            .addHeader(HttpUrlConnectionBuilder.HTTP_HEADER_AUTHORIZATION, "Bearer $apiKey")
+            .addHeader("Content-Type", "application/json")
+            .setFixedLengthForStreaming(json.size)
+            .build()
+
+        val client = BlockingHttpClient(conn)
+        client.execute(json) { stream ->
+            val responseJson = stream.readBytes().toString(Charsets.UTF_8)
+            Json.decodeFromString<GroqResponse>(responseJson).text
+        }
+    }
+
+    suspend fun testConnection(apiKey: String): Boolean = withContext(Dispatchers.IO) {
+        return@withContext try {
+            val conn = HttpUrlConnectionBuilder()
+                .setUrl("https://api.groq.com/openai/v1/models")
+                .setMode(HttpUrlConnectionBuilder.MODE_DOWNLOAD_ONLY)
+                .addHeader(HttpUrlConnectionBuilder.HTTP_HEADER_AUTHORIZATION, "Bearer $apiKey")
+                .build()
+            val client = BlockingHttpClient(conn)
+            client.execute(null) { true }
+        } catch(_: Exception) {
+            false
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Groq API key BuildConfig field
- allow enabling Groq cloud whisper
- support concurrent Groq and local transcription with fallback
- add test option and strings
- expose new Groq setting in UI

## Testing
- `./gradlew assembleUnstableDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68676398fd308327b1948952e9af51c4