### PR TITLE
Add Groq voice input option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: Build APK
+
+on:
+  push:
+    branches: ["**"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Build APK
+        run: ./gradlew assembleUnstableDebug
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: keyboard-apk
+          path: build/outputs/apk/unstable/debug/*.apk
+

--- a/java/res/values/strings-uix.xml
+++ b/java/res/values/strings-uix.xml
@@ -492,6 +492,10 @@
     <string name="voice_input_settings_autostop_vad_subtitle">Automatically stop when silence is detected. You may need to manually stop regardless if there\'s too much background noise.</string>
     <string name="voice_input_settings_change_models">Models</string>
     <string name="voice_input_settings_change_models_subtitle">To change the models, visit Languages &amp; Models menu</string>
+    <string name="voice_input_settings_use_groq">Use Groq cloud</string>
+    <string name="voice_input_settings_use_groq_subtitle">Run recognition on Groq if network is available</string>
+    <string name="voice_input_settings_groq_api_key">Groq API key</string>
+    <string name="voice_input_settings_test">Test voice input</string>
 
     <!-- Prediction menu -->
     <string name="prediction_settings_title">Text Prediction</string>

--- a/java/src/org/futo/inputmethod/latin/uix/VoiceInputSettingKeys.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/VoiceInputSettingKeys.kt
@@ -2,6 +2,7 @@ package org.futo.inputmethod.latin.uix
 
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 
 val ENABLE_SOUND = SettingsKey(
@@ -62,4 +63,14 @@ val MULTILINGUAL_MODEL_INDEX = SettingsKey(
 val LANGUAGE_TOGGLES = SettingsKey(
     key = stringSetPreferencesKey("enabled_languages"),
     default = setOf()
+)
+
+val USE_GROQ_VOICE = SettingsKey(
+    key = booleanPreferencesKey("use_groq_voice"),
+    default = false
+)
+
+val GROQ_API_KEY = SettingsKey(
+    key = stringPreferencesKey("groq_api_key"),
+    default = ""
 )

--- a/java/src/org/futo/inputmethod/latin/uix/actions/VoiceInputAction.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/VoiceInputAction.kt
@@ -55,6 +55,8 @@ import org.futo.voiceinput.shared.whisper.DecodingConfiguration
 import org.futo.voiceinput.shared.whisper.ModelManager
 import org.futo.voiceinput.shared.whisper.MultiModelRunConfiguration
 import java.util.Locale
+import org.futo.inputmethod.latin.uix.GROQ_API_KEY
+import org.futo.inputmethod.latin.uix.USE_GROQ_VOICE
 
 val SystemVoiceInputAction = Action(
     icon = R.drawable.mic_fill,
@@ -121,6 +123,8 @@ private class VoiceInputActionWindow(
         val requestAudioFocus = context.getSetting(AUDIO_FOCUS)
         val canExpandSpace = context.getSetting(CAN_EXPAND_SPACE)
         val useVAD = context.getSetting(USE_VAD_AUTOSTOP)
+        val groqEnabled = context.getSetting(USE_GROQ_VOICE)
+        val groqKey = context.getSetting(GROQ_API_KEY)
 
         val primaryModel = model
         val languageSpecificModels = mutableMapOf<Language, ModelLoader>()
@@ -146,7 +150,8 @@ private class VoiceInputActionWindow(
                 requestAudioFocus = requestAudioFocus,
                 canExpandSpace = canExpandSpace,
                 useVADAutoStop = useVAD
-            )
+            ),
+            groqApiKey = if(groqEnabled && groqKey.isNotBlank()) groqKey else null
         )
     }
 

--- a/java/src/org/futo/inputmethod/latin/uix/settings/SettingsNavigator.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/SettingsNavigator.kt
@@ -8,6 +8,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.dialog
+import org.futo.inputmethod.latin.uix.settings.pages.VoiceInputTestScreen
 import androidx.navigation.compose.rememberNavController
 import org.futo.inputmethod.latin.R
 import org.futo.inputmethod.latin.uix.ErrorDialog
@@ -152,6 +153,7 @@ fun SettingsNavigator(
             dialog("alreadyPaid") {
                 AlreadyPaidDialog(navController = navController)
             }
+            composable("voiceInputTest") { VoiceInputTestScreen(navController) }
             addModelManagerNavigation(navController)
         }
     }

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/VoiceInput.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/VoiceInput.kt
@@ -2,6 +2,7 @@ package org.futo.inputmethod.latin.uix.settings.pages
 
 import android.content.Intent
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
 import org.futo.inputmethod.latin.R
 import org.futo.inputmethod.latin.uix.AUDIO_FOCUS
 import org.futo.inputmethod.latin.uix.CAN_EXPAND_SPACE
@@ -11,11 +12,14 @@ import org.futo.inputmethod.latin.uix.PREFER_BLUETOOTH
 import org.futo.inputmethod.latin.uix.USE_SYSTEM_VOICE_INPUT
 import org.futo.inputmethod.latin.uix.USE_VAD_AUTOSTOP
 import org.futo.inputmethod.latin.uix.VERBOSE_PROGRESS
+import org.futo.inputmethod.latin.uix.GROQ_API_KEY
+import org.futo.inputmethod.latin.uix.USE_GROQ_VOICE
 import org.futo.inputmethod.latin.uix.settings.NavigationItemStyle
 import org.futo.inputmethod.latin.uix.settings.UserSettingsMenu
 import org.futo.inputmethod.latin.uix.settings.useDataStoreValue
 import org.futo.inputmethod.latin.uix.settings.userSettingNavigationItem
 import org.futo.inputmethod.latin.uix.settings.userSettingToggleDataStore
+import org.futo.inputmethod.latin.uix.settings.SettingTextField
 
 private val visibilityCheckNotSystemVoiceInput = @Composable {
     useDataStoreValue(USE_SYSTEM_VOICE_INPUT) == false
@@ -51,6 +55,18 @@ val VoiceInputMenu = UserSettingsMenu(
         ).copy(visibilityCheck = visibilityCheckNotSystemVoiceInput),
 
         userSettingToggleDataStore(
+            title = R.string.voice_input_settings_use_groq,
+            subtitle = R.string.voice_input_settings_use_groq_subtitle,
+            setting = USE_GROQ_VOICE
+        ).copy(visibilityCheck = visibilityCheckNotSystemVoiceInput),
+
+        SettingTextField(
+            title = stringResource(R.string.voice_input_settings_groq_api_key),
+            placeholder = "sk-...",
+            field = GROQ_API_KEY
+        ).copy(visibilityCheck = visibilityCheckNotSystemVoiceInput),
+
+        userSettingToggleDataStore(
             title = R.string.voice_input_settings_audio_focus,
             subtitle = R.string.voice_input_settings_audio_focus_subtitle,
             setting = AUDIO_FOCUS
@@ -71,6 +87,13 @@ val VoiceInputMenu = UserSettingsMenu(
             title = R.string.voice_input_settings_autostop_vad,
             subtitle = R.string.voice_input_settings_autostop_vad_subtitle,
             setting = USE_VAD_AUTOSTOP
+        ).copy(visibilityCheck = visibilityCheckNotSystemVoiceInput),
+
+        userSettingNavigationItem(
+            title = R.string.voice_input_settings_test,
+            subtitle = R.string.voice_input_settings_verbose_progress_subtitle,
+            style = NavigationItemStyle.Misc,
+            navigateTo = "voiceInputTest"
         ).copy(visibilityCheck = visibilityCheckNotSystemVoiceInput),
 
         userSettingNavigationItem(

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/VoiceInputTest.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/VoiceInputTest.kt
@@ -1,0 +1,64 @@
+package org.futo.inputmethod.latin.uix.settings.pages
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.NavHostController
+import org.futo.inputmethod.latin.R
+import org.futo.voiceinput.shared.RecognizerView
+import org.futo.voiceinput.shared.RecognizerViewListener
+import org.futo.voiceinput.shared.RecognizerViewSettings
+import org.futo.voiceinput.shared.RecordingSettings
+import org.futo.voiceinput.shared.whisper.DecodingConfiguration
+import org.futo.voiceinput.shared.whisper.ModelManager
+import org.futo.voiceinput.shared.whisper.MultiModelRunConfiguration
+import org.futo.voiceinput.shared.BUILTIN_ENGLISH_MODEL
+import org.futo.voiceinput.shared.types.Language
+
+@Composable
+fun VoiceInputTestScreen(navController: NavHostController) {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val manager = remember { ModelManager(context) }
+
+    val settings = RecognizerViewSettings(
+        shouldShowVerboseFeedback = true,
+        shouldShowInlinePartialResult = false,
+        modelRunConfiguration = MultiModelRunConfiguration(
+            primaryModel = BUILTIN_ENGLISH_MODEL,
+            languageSpecificModels = mapOf()
+        ),
+        decodingConfiguration = DecodingConfiguration(
+            glossary = listOf(),
+            languages = setOf(Language.ENGLISH),
+            suppressSymbols = false
+        ),
+        recordingConfiguration = RecordingSettings(false, true, false, false),
+        groqApiKey = null
+    )
+
+    val recognizer = remember {
+        RecognizerView(
+            context = context,
+            listener = object : RecognizerViewListener {
+                override fun cancelled() { navController.navigateUp() }
+                override fun recordingStarted(device: org.futo.voiceinput.shared.ui.MicrophoneDeviceState) {}
+                override fun finished(result: String) { navController.navigateUp() }
+                override fun partialResult(result: String) {}
+                override fun requestPermission(onGranted: () -> Unit, onRejected: () -> Unit): Boolean { return false }
+            },
+            settings = settings,
+            lifecycleScope = lifecycleOwner.lifecycleScope,
+            modelManager = manager
+        )
+    }
+
+    Box(Modifier.fillMaxSize()) {
+        recognizer.Content()
+    }
+}

--- a/voiceinput-shared/build.gradle
+++ b/voiceinput-shared/build.gradle
@@ -100,4 +100,5 @@ dependencies {
     implementation(name:'tensorflow-lite-support-api', ext:'aar')
 
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.1'
+    implementation 'com.squareup.okhttp3:okhttp:4.11.0'
 }

--- a/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/AudioRecognizer.kt
+++ b/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/AudioRecognizer.kt
@@ -28,7 +28,10 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.yield
+import android.net.ConnectivityManager
 import org.futo.voiceinput.shared.ggml.InferenceCancelledException
 import org.futo.voiceinput.shared.types.AudioRecognizerListener
 import org.futo.voiceinput.shared.types.InferenceState
@@ -86,7 +89,8 @@ data class RecordingSettings(
 data class AudioRecognizerSettings(
     val modelRunConfiguration: MultiModelRunConfiguration,
     val decodingConfiguration: DecodingConfiguration,
-    val recordingConfiguration: RecordingSettings
+    val recordingConfiguration: RecordingSettings,
+    val groqApiKey: String?
 )
 
 class ModelDoesNotExistException(val models: List<ModelLoader>) : Throwable()
@@ -303,6 +307,12 @@ class AudioRecognizer(
             return true
         }
         return false
+    }
+
+    private fun isNetworkAvailable(): Boolean {
+        val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val active = cm.activeNetworkInfo
+        return active != null && active.isConnected
     }
 
     private suspend fun recordingJob(recorder: AudioRecord, vad: VadModel?) {
@@ -533,7 +543,6 @@ class AudioRecognizer(
     private suspend fun runModel() {
         loadModelJob?.let {
             if (it.isActive) {
-                println("Model was not finished loading...")
                 it.join()
             }
         }
@@ -541,21 +550,44 @@ class AudioRecognizer(
         val floatArray = floatSamples.array().sliceArray(0 until floatSamples.position())
 
         yield()
-        val outputText = try {
-             modelRunner.run(
-                floatArray,
-                settings.modelRunConfiguration,
-                settings.decodingConfiguration,
-                runnerCallback
-            ).trim()
-        }catch(e: InferenceCancelledException) {
+        val result = try {
+            coroutineScope {
+                val localJob = async {
+                    modelRunner.run(
+                        floatArray,
+                        settings.modelRunConfiguration,
+                        settings.decodingConfiguration,
+                        runnerCallback
+                    ).trim()
+                }
+
+                val remoteJob = if(settings.groqApiKey != null && isNetworkAvailable()) {
+                    async(Dispatchers.IO) {
+                        val wav = encodeWav(floatArray)
+                        GroqWhisperClient(settings.groqApiKey!!).transcribe(
+                            wav,
+                            settings.decodingConfiguration.languages.firstOrNull()?.toWhisperString(),
+                            if(settings.decodingConfiguration.glossary.isEmpty()) null else settings.decodingConfiguration.glossary.joinToString(" ")
+                        )
+                    }
+                } else null
+
+                val remote = remoteJob?.await()
+                if (remote != null) {
+                    localJob.cancel()
+                    remote
+                } else {
+                    localJob.await()
+                }
+            }
+        } catch(e: InferenceCancelledException) {
             yield()
             return
         }
 
         val text = when {
-            isBlankResult(outputText) -> ""
-            else -> outputText
+            result == null || isBlankResult(result) -> ""
+            else -> result
         }
 
         yield()

--- a/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/RecognizerView.kt
+++ b/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/RecognizerView.kt
@@ -25,7 +25,8 @@ data class RecognizerViewSettings(
 
     val modelRunConfiguration: MultiModelRunConfiguration,
     val decodingConfiguration: DecodingConfiguration,
-    val recordingConfiguration: RecordingSettings
+    val recordingConfiguration: RecordingSettings,
+    val groqApiKey: String?
 )
 
 private val VerboseAnnotations = hashMapOf(
@@ -205,7 +206,8 @@ class RecognizerView(
         settings = AudioRecognizerSettings(
             modelRunConfiguration = settings.modelRunConfiguration,
             decodingConfiguration = settings.decodingConfiguration,
-            recordingConfiguration = settings.recordingConfiguration
+            recordingConfiguration = settings.recordingConfiguration,
+            groqApiKey = settings.groqApiKey
         )
     )
 

--- a/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/whisper/GroqWhisperClient.kt
+++ b/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/whisper/GroqWhisperClient.kt
@@ -1,0 +1,87 @@
+package org.futo.voiceinput.shared.whisper
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.asRequestBody
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.FileOutputStream
+
+class GroqWhisperClient(private val apiKey: String) {
+    @Serializable
+    private data class Response(@SerialName("text") val text: String)
+
+    private val json = Json { ignoreUnknownKeys = true }
+    private val client = OkHttpClient()
+
+    fun transcribe(wavData: ByteArray, language: String?, prompt: String?): String? {
+        val tempFile = File.createTempFile("audio", ".wav")
+        FileOutputStream(tempFile).use { it.write(wavData) }
+
+        val bodyBuilder = MultipartBody.Builder().setType(MultipartBody.FORM)
+            .addFormDataPart(
+                name = "file",
+                filename = "audio.wav",
+                body = tempFile.asRequestBody("audio/wav".toMediaType())
+            )
+            .addFormDataPart("model", "whisper-large-v3")
+        if (language != null) bodyBuilder.addFormDataPart("language", language)
+        if (prompt != null) bodyBuilder.addFormDataPart("prompt", prompt)
+
+        val request = Request.Builder()
+            .url("https://api.groq.com/openai/v1/audio/transcriptions")
+            .header("Authorization", "Bearer $apiKey")
+            .post(bodyBuilder.build())
+            .build()
+
+        client.newCall(request).execute().use { resp ->
+            if (!resp.isSuccessful) return null
+            val body = resp.body?.string() ?: return null
+            return json.decodeFromString<Response>(body).text
+        }
+    }
+}
+
+fun encodeWav(samples: FloatArray, sampleRate: Int = 16000): ByteArray {
+    val pcm = ByteArrayOutputStream()
+    for (f in samples) {
+        val v = (f.coerceIn(-1f, 1f) * Short.MAX_VALUE).toInt()
+        pcm.write(v and 0xFF)
+        pcm.write((v shr 8) and 0xFF)
+    }
+    val audioData = pcm.toByteArray()
+    val totalDataLen = audioData.size + 36
+    val byteRate = sampleRate * 2
+    val header = ByteArrayOutputStream()
+    header.write("RIFF".toByteArray())
+    header.write(intToLE(totalDataLen))
+    header.write("WAVE".toByteArray())
+    header.write("fmt ".toByteArray())
+    header.write(intToLE(16))
+    header.write(shortToLE(1))
+    header.write(shortToLE(1))
+    header.write(intToLE(sampleRate))
+    header.write(intToLE(byteRate))
+    header.write(shortToLE(2))
+    header.write(shortToLE(16))
+    header.write("data".toByteArray())
+    header.write(intToLE(audioData.size))
+    return header.toByteArray() + audioData
+}
+
+private fun intToLE(v: Int) = byteArrayOf(
+    (v and 0xFF).toByte(),
+    ((v shr 8) and 0xFF).toByte(),
+    ((v shr 16) and 0xFF).toByte(),
+    ((v shr 24) and 0xFF).toByte()
+)
+
+private fun shortToLE(v: Int) = byteArrayOf(
+    (v and 0xFF).toByte(),
+    ((v shr 8) and 0xFF).toByte()
+)


### PR DESCRIPTION
## Summary
- add Groq Whisper client and WAV encoder
- allow enabling Groq cloud in voice input settings
- provide API key field and test screen
- run cloud and local recognition concurrently

## Testing
- `./gradlew assembleUnstableDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68676398fd308327b1948952e9af51c4