### PR TITLE
Add optional Groq API transcription

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -306,7 +306,7 @@ dependencies {
 
     implementation 'sh.calvin.reorderable:reorderable:2.2.0'
 
-    //implementation 'com.squareup.okhttp3:okhttp:4.11.0'
+    implementation 'com.squareup.okhttp3:okhttp:4.11.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.1'
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json-jvm:1.7.1'
 

--- a/java/res/values/strings-uix.xml
+++ b/java/res/values/strings-uix.xml
@@ -492,6 +492,9 @@
     <string name="voice_input_settings_autostop_vad_subtitle">Automatically stop when silence is detected. You may need to manually stop regardless if there\'s too much background noise.</string>
     <string name="voice_input_settings_change_models">Models</string>
     <string name="voice_input_settings_change_models_subtitle">To change the models, visit Languages &amp; Models menu</string>
+    <string name="voice_input_settings_test_groq">Test Groq Recognition</string>
+    <string name="voice_input_settings_test_groq_subtitle">Run a short test using Groq API</string>
+    <string name="voice_input_settings_groq_api_key">Groq API Key</string>
 
     <!-- Prediction menu -->
     <string name="prediction_settings_title">Text Prediction</string>

--- a/java/src/org/futo/inputmethod/latin/uix/Settings.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/Settings.kt
@@ -367,3 +367,8 @@ val SHOW_EMOJI_SUGGESTIONS = SettingsKey(
     key = booleanPreferencesKey("suggestEmojis"),
     default = true
 )
+
+val GROQ_API_KEY = SettingsKey(
+    key = stringPreferencesKey("groqApiKey"),
+    default = ""
+)

--- a/java/src/org/futo/inputmethod/latin/uix/actions/VoiceInputAction.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/VoiceInputAction.kt
@@ -41,6 +41,7 @@ import org.futo.inputmethod.latin.uix.setSetting
 import org.futo.inputmethod.latin.uix.utils.ModelOutputSanitizer
 import org.futo.inputmethod.latin.xlm.UserDictionaryObserver
 import org.futo.inputmethod.updates.openURI
+import org.futo.inputmethod.latin.uix.GROQ_API_KEY
 import org.futo.voiceinput.shared.ModelDoesNotExistException
 import org.futo.voiceinput.shared.RecognizerView
 import org.futo.voiceinput.shared.RecognizerViewListener
@@ -121,6 +122,7 @@ private class VoiceInputActionWindow(
         val requestAudioFocus = context.getSetting(AUDIO_FOCUS)
         val canExpandSpace = context.getSetting(CAN_EXPAND_SPACE)
         val useVAD = context.getSetting(USE_VAD_AUTOSTOP)
+        val groqKey = context.getSetting(GROQ_API_KEY)
 
         val primaryModel = model
         val languageSpecificModels = mutableMapOf<Language, ModelLoader>()
@@ -146,7 +148,8 @@ private class VoiceInputActionWindow(
                 requestAudioFocus = requestAudioFocus,
                 canExpandSpace = canExpandSpace,
                 useVADAutoStop = useVAD
-            )
+            ),
+            groqApiKey = groqKey
         )
     }
 

--- a/java/src/org/futo/inputmethod/latin/uix/settings/SettingsNavigator.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/SettingsNavigator.kt
@@ -50,6 +50,7 @@ import org.futo.inputmethod.latin.uix.settings.pages.SelectLayoutsScreen
 import org.futo.inputmethod.latin.uix.settings.pages.ThemeScreen
 import org.futo.inputmethod.latin.uix.settings.pages.TypingSettingsMenu
 import org.futo.inputmethod.latin.uix.settings.pages.VoiceInputMenu
+import org.futo.inputmethod.latin.uix.settings.pages.GroqTestDialog
 import org.futo.inputmethod.latin.uix.settings.pages.addModelManagerNavigation
 import org.futo.inputmethod.latin.uix.urlDecode
 import org.futo.inputmethod.latin.uix.urlEncode
@@ -151,6 +152,9 @@ fun SettingsNavigator(
             }
             dialog("alreadyPaid") {
                 AlreadyPaidDialog(navController = navController)
+            }
+            dialog("groqtest") {
+                GroqTestDialog(navController = navController)
             }
             addModelManagerNavigation(navController)
         }

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/VoiceInput.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/VoiceInput.kt
@@ -2,6 +2,7 @@ package org.futo.inputmethod.latin.uix.settings.pages
 
 import android.content.Intent
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
 import org.futo.inputmethod.latin.R
 import org.futo.inputmethod.latin.uix.AUDIO_FOCUS
 import org.futo.inputmethod.latin.uix.CAN_EXPAND_SPACE
@@ -16,6 +17,9 @@ import org.futo.inputmethod.latin.uix.settings.UserSettingsMenu
 import org.futo.inputmethod.latin.uix.settings.useDataStoreValue
 import org.futo.inputmethod.latin.uix.settings.userSettingNavigationItem
 import org.futo.inputmethod.latin.uix.settings.userSettingToggleDataStore
+import org.futo.inputmethod.latin.uix.settings.userSettingDecorationOnly
+import org.futo.inputmethod.latin.uix.settings.SettingTextField
+import org.futo.inputmethod.latin.uix.GROQ_API_KEY
 
 private val visibilityCheckNotSystemVoiceInput = @Composable {
     useDataStoreValue(USE_SYSTEM_VOICE_INPUT) == false
@@ -79,6 +83,21 @@ val VoiceInputMenu = UserSettingsMenu(
             style = NavigationItemStyle.Misc,
             navigateTo = "languages"
         ).copy(visibilityCheck = visibilityCheckNotSystemVoiceInput),
+
+        userSettingNavigationItem(
+            title = R.string.voice_input_settings_test_groq,
+            subtitle = R.string.voice_input_settings_test_groq_subtitle,
+            style = NavigationItemStyle.Misc,
+            navigateTo = "groqtest"
+        ).copy(visibilityCheck = visibilityCheckNotSystemVoiceInput),
+
+        userSettingDecorationOnly {
+            SettingTextField(
+                title = stringResource(R.string.voice_input_settings_groq_api_key),
+                placeholder = "sk-...",
+                field = GROQ_API_KEY
+            )
+        }.copy(visibilityCheck = visibilityCheckNotSystemVoiceInput),
         //}
     )
 )

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/VoiceInputGroqTest.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/VoiceInputGroqTest.kt
@@ -1,0 +1,52 @@
+package org.futo.inputmethod.latin.uix.settings.pages
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.res.stringResource
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.NavHostController
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import kotlinx.coroutines.launch
+import org.futo.inputmethod.latin.R
+import org.futo.inputmethod.latin.uix.GROQ_API_KEY
+import org.futo.inputmethod.latin.uix.getSetting
+import org.futo.voiceinput.shared.whisper.GroqWhisperClient
+import org.futo.voiceinput.shared.whisper.toWav
+
+@Composable
+fun GroqTestDialog(navController: NavHostController) {
+    val context = LocalContext.current
+    val scope = LocalLifecycleOwner.current
+    val result = remember { mutableStateOf("") }
+    val running = remember { mutableStateOf(false) }
+
+    AlertDialog(
+        onDismissRequest = { if(!running.value) navController.navigateUp() },
+        title = { Text(stringResource(R.string.voice_input_settings_test_groq)) },
+        text = { Text(if(result.value.isBlank()) stringResource(R.string.voice_input_settings_test_groq_subtitle) else result.value) },
+        confirmButton = {
+            TextButton(enabled = !running.value, onClick = {
+                running.value = true
+                scope.lifecycleScope.launch {
+                    val key = context.getSetting(GROQ_API_KEY)
+                    val wav = FloatArray(16000) { 0f }.toWav()
+                    val r = GroqWhisperClient.transcribeWav(wav, key)
+                    result.value = r ?: "Failed"
+                    running.value = false
+                }
+            }) {
+                Text(stringResource(android.R.string.ok))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = { navController.navigateUp() }, enabled = !running.value) {
+                Text(stringResource(R.string.cancel))
+            }
+        }
+    )
+}

--- a/voiceinput-shared/build.gradle
+++ b/voiceinput-shared/build.gradle
@@ -100,4 +100,5 @@ dependencies {
     implementation(name:'tensorflow-lite-support-api', ext:'aar')
 
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.1'
+    implementation 'com.squareup.okhttp3:okhttp:4.11.0'
 }

--- a/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/AudioRecognizer.kt
+++ b/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/AudioRecognizer.kt
@@ -25,7 +25,10 @@ import com.konovalov.vad.config.SampleRate
 import com.konovalov.vad.models.VadModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
@@ -41,6 +44,8 @@ import org.futo.voiceinput.shared.whisper.DecodingConfiguration
 import org.futo.voiceinput.shared.whisper.ModelManager
 import org.futo.voiceinput.shared.whisper.MultiModelRunConfiguration
 import org.futo.voiceinput.shared.whisper.MultiModelRunner
+import org.futo.voiceinput.shared.whisper.GroqWhisperClient
+import org.futo.voiceinput.shared.whisper.toWav
 import org.futo.voiceinput.shared.whisper.isBlankResult
 import java.nio.FloatBuffer
 import java.nio.ShortBuffer
@@ -86,7 +91,8 @@ data class RecordingSettings(
 data class AudioRecognizerSettings(
     val modelRunConfiguration: MultiModelRunConfiguration,
     val decodingConfiguration: DecodingConfiguration,
-    val recordingConfiguration: RecordingSettings
+    val recordingConfiguration: RecordingSettings,
+    val groqApiKey: String?
 )
 
 class ModelDoesNotExistException(val models: List<ModelLoader>) : Throwable()
@@ -541,16 +547,39 @@ class AudioRecognizer(
         val floatArray = floatSamples.array().sliceArray(0 until floatSamples.position())
 
         yield()
-        val outputText = try {
-             modelRunner.run(
-                floatArray,
-                settings.modelRunConfiguration,
-                settings.decodingConfiguration,
-                runnerCallback
-            ).trim()
-        }catch(e: InferenceCancelledException) {
-            yield()
-            return
+
+        val localJob = lifecycleScope.async(Dispatchers.Default) {
+            try {
+                modelRunner.run(
+                    floatArray,
+                    settings.modelRunConfiguration,
+                    settings.decodingConfiguration,
+                    runnerCallback
+                ).trim()
+            } catch(_: InferenceCancelledException) {
+                ""
+            }
+        }
+
+        val remoteJob = settings.groqApiKey?.takeIf { it.isNotBlank() }?.let { key ->
+            lifecycleScope.async(Dispatchers.IO) {
+                try {
+                    GroqWhisperClient.transcribeWav(floatArray.toWav(), key) ?: ""
+                } catch(_: Exception) { "" }
+            }
+        }
+
+        val outputText = coroutineScope {
+            select<String> {
+                localJob.onAwait { res ->
+                    remoteJob?.cancel()
+                    res
+                }
+                remoteJob?.onAwait { res ->
+                    if(res.isNotBlank()) localJob.cancel()
+                    res
+                }
+            }
         }
 
         val text = when {

--- a/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/RecognizerView.kt
+++ b/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/RecognizerView.kt
@@ -25,7 +25,8 @@ data class RecognizerViewSettings(
 
     val modelRunConfiguration: MultiModelRunConfiguration,
     val decodingConfiguration: DecodingConfiguration,
-    val recordingConfiguration: RecordingSettings
+    val recordingConfiguration: RecordingSettings,
+    val groqApiKey: String?
 )
 
 private val VerboseAnnotations = hashMapOf(
@@ -205,7 +206,8 @@ class RecognizerView(
         settings = AudioRecognizerSettings(
             modelRunConfiguration = settings.modelRunConfiguration,
             decodingConfiguration = settings.decodingConfiguration,
-            recordingConfiguration = settings.recordingConfiguration
+            recordingConfiguration = settings.recordingConfiguration,
+            groqApiKey = settings.groqApiKey
         )
     )
 

--- a/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/whisper/GroqWhisperClient.kt
+++ b/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/whisper/GroqWhisperClient.kt
@@ -1,0 +1,47 @@
+package org.futo.voiceinput.shared.whisper
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.asRequestBody
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.io.FileOutputStream
+import java.util.concurrent.TimeUnit
+
+@Serializable
+private data class TranscriptionResponse(val text: String?)
+
+object GroqWhisperClient {
+    private val client = OkHttpClient.Builder()
+        .connectTimeout(15, TimeUnit.SECONDS)
+        .readTimeout(120, TimeUnit.SECONDS)
+        .build()
+
+    suspend fun transcribeWav(wavData: ByteArray, apiKey: String): String? = withContext(Dispatchers.IO) {
+        val tmp = File.createTempFile("voice", ".wav")
+        FileOutputStream(tmp).use { it.write(wavData) }
+
+        val requestBody = MultipartBody.Builder().setType(MultipartBody.FORM)
+            .addFormDataPart("file", "audio.wav", tmp.asRequestBody("audio/wav".toMediaType()))
+            .addFormDataPart("model", "whisper-large")
+            .build()
+
+        val request = Request.Builder()
+            .url("https://api.groq.com/openai/v1/audio/transcriptions")
+            .post(requestBody)
+            .addHeader("Authorization", "Bearer $apiKey")
+            .build()
+
+        client.newCall(request).execute().use { resp ->
+            if(!resp.isSuccessful) return@use null
+            val body = resp.body?.string() ?: return@use null
+            return@withContext Json.decodeFromString<TranscriptionResponse>(body).text
+        }
+    }
+}

--- a/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/whisper/WavUtil.kt
+++ b/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/whisper/WavUtil.kt
@@ -1,0 +1,27 @@
+package org.futo.voiceinput.shared.whisper
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+fun FloatArray.toWav(sampleRate: Int = 16000): ByteArray {
+    val buffer = ByteBuffer.allocate(44 + size * 2)
+    buffer.order(ByteOrder.LITTLE_ENDIAN)
+    buffer.put("RIFF".toByteArray())
+    buffer.putInt(36 + size * 2)
+    buffer.put("WAVE".toByteArray())
+    buffer.put("fmt ".toByteArray())
+    buffer.putInt(16)
+    buffer.putShort(1)
+    buffer.putShort(1)
+    buffer.putInt(sampleRate)
+    buffer.putInt(sampleRate * 2)
+    buffer.putShort(2)
+    buffer.putShort(16)
+    buffer.put("data".toByteArray())
+    buffer.putInt(size * 2)
+    for (f in this) {
+        val s = (f.coerceIn(-1f, 1f) * Short.MAX_VALUE).toInt().toShort()
+        buffer.putShort(s)
+    }
+    return buffer.array()
+}


### PR DESCRIPTION
## Summary
- support remote speech recognition via Groq API
- fall back to local whisper when Groq fails
- allow configuring Groq API key and run a quick test from Voice Input settings
- include OkHttp for network calls

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867764aaea88327b7846897904ef6e4