### PR TITLE
Add Groq API fallback and test page

### DIFF
--- a/java/res/values/strings-uix.xml
+++ b/java/res/values/strings-uix.xml
@@ -492,6 +492,8 @@
     <string name="voice_input_settings_autostop_vad_subtitle">Automatically stop when silence is detected. You may need to manually stop regardless if there\'s too much background noise.</string>
     <string name="voice_input_settings_change_models">Models</string>
     <string name="voice_input_settings_change_models_subtitle">To change the models, visit Languages &amp; Models menu</string>
+    <string name="voice_input_settings_test">Test voice input</string>
+    <string name="voice_input_settings_test_subtitle">Run a quick voice input test</string>
 
     <!-- Prediction menu -->
     <string name="prediction_settings_title">Text Prediction</string>

--- a/java/src/org/futo/inputmethod/latin/uix/settings/SettingsNavigator.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/SettingsNavigator.kt
@@ -50,6 +50,7 @@ import org.futo.inputmethod.latin.uix.settings.pages.SelectLayoutsScreen
 import org.futo.inputmethod.latin.uix.settings.pages.ThemeScreen
 import org.futo.inputmethod.latin.uix.settings.pages.TypingSettingsMenu
 import org.futo.inputmethod.latin.uix.settings.pages.VoiceInputMenu
+import org.futo.inputmethod.latin.uix.settings.pages.VoiceInputTestScreen
 import org.futo.inputmethod.latin.uix.settings.pages.addModelManagerNavigation
 import org.futo.inputmethod.latin.uix.urlDecode
 import org.futo.inputmethod.latin.uix.urlEncode
@@ -105,6 +106,7 @@ fun SettingsNavigator(
             SettingsMenus.forEach { menu ->
                 if(menu.registerNavPath) composable(menu.navPath) { UserSettingsMenuScreen(menu) }
             }
+            composable("voiceInputTest") { VoiceInputTestScreen(navController) }
             composable("keyboardAndTyping") { KeyboardAndTypingScreen(navController) }
             composable("resize") { ResizeScreen(navController) }
             composable("themes") { ThemeScreen(navController) }

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/VoiceInput.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/VoiceInput.kt
@@ -79,6 +79,12 @@ val VoiceInputMenu = UserSettingsMenu(
             style = NavigationItemStyle.Misc,
             navigateTo = "languages"
         ).copy(visibilityCheck = visibilityCheckNotSystemVoiceInput),
+        userSettingNavigationItem(
+            title = R.string.voice_input_settings_test,
+            subtitle = R.string.voice_input_settings_test_subtitle,
+            style = NavigationItemStyle.Misc,
+            navigateTo = "voiceInputTest"
+        ).copy(visibilityCheck = visibilityCheckNotSystemVoiceInput),
         //}
     )
 )

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/VoiceInputTest.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/VoiceInputTest.kt
@@ -1,0 +1,63 @@
+package org.futo.inputmethod.latin.uix.settings.pages
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.NavHostController
+import org.futo.voiceinput.shared.RecognizerView
+import org.futo.voiceinput.shared.RecognizerViewListener
+import org.futo.voiceinput.shared.RecognizerViewSettings
+import org.futo.voiceinput.shared.RecordingSettings
+import org.futo.voiceinput.shared.types.Language
+import org.futo.voiceinput.shared.whisper.DecodingConfiguration
+import org.futo.voiceinput.shared.whisper.ModelManager
+import org.futo.voiceinput.shared.whisper.MultiModelRunConfiguration
+import java.util.Locale
+
+@Composable
+fun VoiceInputTestScreen(navController: NavHostController) {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val lifecycleScope = lifecycleOwner.lifecycleScope
+    val modelManager = remember { ModelManager(context) }
+    val recognizerView = remember { mutableStateOf<RecognizerView?>(null) }
+
+    LaunchedEffect(Unit) {
+        val model = org.futo.inputmethod.latin.uix.ResourceHelper.tryFindingVoiceInputModelForLocale(context, Locale.getDefault())
+            ?: return@LaunchedEffect
+        val settings = RecognizerViewSettings(
+            shouldShowVerboseFeedback = true,
+            shouldShowInlinePartialResult = true,
+            modelRunConfiguration = MultiModelRunConfiguration(model, mapOf()),
+            decodingConfiguration = DecodingConfiguration(glossary = emptyList(), languages = setOf(Language.English), suppressSymbols = false),
+            recordingConfiguration = RecordingSettings(preferBluetoothMic = false, requestAudioFocus = true, canExpandSpace = false, useVADAutoStop = true)
+        )
+        recognizerView.value = RecognizerView(
+            context = context,
+            listener = object : RecognizerViewListener {
+                override fun cancelled() { }
+                override fun recordingStarted(device: org.futo.voiceinput.shared.ui.MicrophoneDeviceState) { }
+                override fun finished(result: String) { }
+                override fun partialResult(result: String) { }
+                override fun requestPermission(onGranted: () -> Unit, onRejected: () -> Unit): Boolean { return false }
+            },
+            settings = settings,
+            lifecycleScope = lifecycleScope,
+            modelManager = modelManager
+        )
+        recognizerView.value?.reset()
+        recognizerView.value?.start()
+    }
+
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        recognizerView.value?.Content()
+    }
+}

--- a/voiceinput-shared/build.gradle
+++ b/voiceinput-shared/build.gradle
@@ -46,6 +46,8 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
+        buildConfigField "String", "GROQ_API_URL", "\"https://api.groq.com/openai/v1/audio/transcriptions\""
+        buildConfigField "String", "GROQ_API_KEY", "\"\""
     }
 
     buildTypes {
@@ -100,4 +102,5 @@ dependencies {
     implementation(name:'tensorflow-lite-support-api', ext:'aar')
 
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.1'
+    implementation 'com.squareup.okhttp3:okhttp:4.11.0'
 }

--- a/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/AudioRecognizer.kt
+++ b/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/AudioRecognizer.kt
@@ -25,6 +25,7 @@ import com.konovalov.vad.config.SampleRate
 import com.konovalov.vad.models.VadModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -42,6 +43,9 @@ import org.futo.voiceinput.shared.whisper.ModelManager
 import org.futo.voiceinput.shared.whisper.MultiModelRunConfiguration
 import org.futo.voiceinput.shared.whisper.MultiModelRunner
 import org.futo.voiceinput.shared.whisper.isBlankResult
+import org.futo.voiceinput.shared.remote.GroqApi
+import org.futo.voiceinput.shared.util.floatArrayToWav
+import java.io.File
 import java.nio.FloatBuffer
 import java.nio.ShortBuffer
 import kotlin.math.min
@@ -541,17 +545,34 @@ class AudioRecognizer(
         val floatArray = floatSamples.array().sliceArray(0 until floatSamples.position())
 
         yield()
-        val outputText = try {
-             modelRunner.run(
-                floatArray,
-                settings.modelRunConfiguration,
-                settings.decodingConfiguration,
-                runnerCallback
-            ).trim()
-        }catch(e: InferenceCancelledException) {
-            yield()
-            return
+        val localJob = lifecycleScope.async(Dispatchers.Default) {
+            try {
+                modelRunner.run(
+                    floatArray,
+                    settings.modelRunConfiguration,
+                    settings.decodingConfiguration,
+                    runnerCallback
+                ).trim()
+            } catch (e: InferenceCancelledException) {
+                ""
+            }
         }
+
+        val groqJob = lifecycleScope.async(Dispatchers.IO) {
+            try {
+                val tmp = File.createTempFile("recording", ".wav", context.cacheDir)
+                tmp.writeBytes(floatArrayToWav(floatArray))
+                val api = GroqApi(BuildConfig.GROQ_API_URL, BuildConfig.GROQ_API_KEY)
+                val language = settings.decodingConfiguration.languages.firstOrNull()?.toWhisperString()
+                val result = api.transcribe(tmp, language)
+                tmp.delete()
+                result
+            } catch (_: Exception) {
+                null
+            }
+        }
+
+        val outputText = groqJob.await() ?: localJob.await()
 
         val text = when {
             isBlankResult(outputText) -> ""

--- a/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/remote/GroqApi.kt
+++ b/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/remote/GroqApi.kt
@@ -1,0 +1,47 @@
+package org.futo.voiceinput.shared.remote
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.asRequestBody
+import java.io.File
+
+@Serializable
+data class GroqResponse(
+    @SerialName("text") val text: String?
+)
+
+class GroqApi(private val url: String, private val apiKey: String) {
+    private val client = OkHttpClient()
+
+    fun transcribe(tempFile: File, language: String?): String? {
+        if (apiKey.isBlank()) return null
+
+        val requestBodyBuilder = MultipartBody.Builder().setType(MultipartBody.FORM)
+            .addFormDataPart("model", "whisper")
+            .addFormDataPart("file", tempFile.name, tempFile.asRequestBody("audio/wav".toMediaType()))
+        if (language != null) {
+            requestBodyBuilder.addFormDataPart("language", language)
+        }
+        val request = Request.Builder()
+            .url(url)
+            .header("Authorization", "Bearer $apiKey")
+            .post(requestBodyBuilder.build())
+            .build()
+
+        client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) return null
+            val body = response.body?.string() ?: return null
+            return try {
+                val parsed = Json.decodeFromString<GroqResponse>(body)
+                parsed.text
+            } catch (_: Exception) {
+                null
+            }
+        }
+    }
+}

--- a/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/util/WavUtils.kt
+++ b/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/util/WavUtils.kt
@@ -1,0 +1,43 @@
+package org.futo.voiceinput.shared.util
+
+import java.io.ByteArrayOutputStream
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+fun floatArrayToWav(samples: FloatArray, sampleRate: Int = 16000): ByteArray {
+    val byteBuffer = ByteBuffer.allocate(44 + samples.size * 2)
+    byteBuffer.order(ByteOrder.LITTLE_ENDIAN)
+
+    fun writeString(value: String) {
+        byteBuffer.put(value.toByteArray())
+    }
+
+    fun writeInt(value: Int) {
+        byteBuffer.putInt(value)
+    }
+
+    fun writeShort(value: Short) {
+        byteBuffer.putShort(value)
+    }
+
+    writeString("RIFF")
+    writeInt(36 + samples.size * 2)
+    writeString("WAVE")
+    writeString("fmt ")
+    writeInt(16)
+    writeShort(1) // PCM
+    writeShort(1) // Mono
+    writeInt(sampleRate)
+    writeInt(sampleRate * 2)
+    writeShort(2)
+    writeShort(16)
+    writeString("data")
+    writeInt(samples.size * 2)
+
+    for(sample in samples) {
+        val s = (sample.coerceIn(-1f, 1f) * Short.MAX_VALUE).toInt().toShort()
+        writeShort(s)
+    }
+
+    return byteBuffer.array()
+}


### PR DESCRIPTION
## Summary
- allow building Groq requests via new `GroqApi` helper
- convert raw audio to wav so HTTP requests can send files
- run Groq API inference concurrently with the local model
- surface a voice input test page within settings
- expose strings for the new settings option

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867764aaea88327b7846897904ef6e4