### PR TITLE
Add Groq Whisper model selection

### DIFF
--- a/java/res/values/strings-uix.xml
+++ b/java/res/values/strings-uix.xml
@@ -499,6 +499,7 @@
 
     <string name="groq_settings_title">Groq API</string>
     <string name="groq_settings_api_key">Groq API key</string>
+    <string name="groq_settings_model">Groq model</string>
     <string name="groq_settings_test">Test connection</string>
     <string name="groq_settings_testing">Testing...</string>
     <string name="groq_settings_success">Success</string>

--- a/java/src/org/futo/inputmethod/latin/uix/VoiceInputSettingKeys.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/VoiceInputSettingKeys.kt
@@ -74,3 +74,8 @@ val GROQ_API_KEY = SettingsKey(
     key = stringPreferencesKey("groq_api_key"),
     default = ""
 )
+
+val GROQ_MODEL = SettingsKey(
+    key = stringPreferencesKey("groq_model"),
+    default = "whisper-large-v3"
+)

--- a/java/src/org/futo/inputmethod/latin/uix/actions/VoiceInputAction.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/VoiceInputAction.kt
@@ -38,6 +38,7 @@ import org.futo.inputmethod.latin.uix.USE_VAD_AUTOSTOP
 import org.futo.inputmethod.latin.uix.VERBOSE_PROGRESS
 import org.futo.inputmethod.latin.uix.USE_GROQ_WHISPER
 import org.futo.inputmethod.latin.uix.GROQ_API_KEY
+import org.futo.inputmethod.latin.uix.GROQ_MODEL
 import org.futo.inputmethod.latin.uix.getSetting
 import org.futo.inputmethod.latin.uix.setSetting
 import org.futo.inputmethod.latin.uix.utils.ModelOutputSanitizer
@@ -125,6 +126,7 @@ private class VoiceInputActionWindow(
         val useVAD = context.getSetting(USE_VAD_AUTOSTOP)
         val useGroq = context.getSetting(USE_GROQ_WHISPER)
         val groqKey = context.getSetting(GROQ_API_KEY)
+        val groqModel = context.getSetting(GROQ_MODEL)
 
         val primaryModel = model
         val languageSpecificModels = mutableMapOf<Language, ModelLoader>()
@@ -151,7 +153,8 @@ private class VoiceInputActionWindow(
                 canExpandSpace = canExpandSpace,
                 useVADAutoStop = useVAD
             ),
-            groqApiKey = if(useGroq) groqKey else ""
+            groqApiKey = if(useGroq) groqKey else "",
+            groqModel = groqModel
         )
     }
 

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/GroqConfig.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/GroqConfig.kt
@@ -12,10 +12,12 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.futo.inputmethod.latin.R
 import org.futo.inputmethod.latin.uix.GROQ_API_KEY
+import org.futo.inputmethod.latin.uix.GROQ_MODEL
 import org.futo.inputmethod.latin.uix.settings.ScrollableList
 import org.futo.inputmethod.latin.uix.settings.ScreenTitle
 import org.futo.inputmethod.latin.uix.settings.SettingItem
 import org.futo.inputmethod.latin.uix.settings.SettingTextField
+import org.futo.inputmethod.latin.uix.settings.DropDownPickerSettingItem
 import org.futo.inputmethod.latin.uix.settings.useDataStore
 import org.futo.voiceinput.shared.groq.GroqWhisperApi
 
@@ -24,6 +26,7 @@ fun GroqConfigScreen(navController: NavHostController = rememberNavController())
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
     val apiKeyItem = useDataStore(GROQ_API_KEY)
+    val modelItem = useDataStore(GROQ_MODEL)
     val testStatus = remember { mutableStateOf("") }
 
     ScrollableList {
@@ -33,6 +36,14 @@ fun GroqConfigScreen(navController: NavHostController = rememberNavController())
             title = stringResource(R.string.groq_settings_api_key),
             placeholder = "sk-...",
             field = GROQ_API_KEY
+        )
+
+        DropDownPickerSettingItem(
+            label = stringResource(R.string.groq_settings_model),
+            options = listOf("whisper-large-v3", "whisper-large-v3-en", "whisper-large-v3-turbo"),
+            selection = modelItem.value,
+            onSet = { modelItem.setValue(it) },
+            getDisplayName = { it }
         )
 
         val testing = stringResource(R.string.groq_settings_testing)

--- a/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/AudioRecognizer.kt
+++ b/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/AudioRecognizer.kt
@@ -88,7 +88,8 @@ data class AudioRecognizerSettings(
     val modelRunConfiguration: MultiModelRunConfiguration,
     val decodingConfiguration: DecodingConfiguration,
     val recordingConfiguration: RecordingSettings,
-    val groqApiKey: String
+    val groqApiKey: String,
+    val groqModel: String
 )
 
 class ModelDoesNotExistException(val models: List<ModelLoader>) : Throwable()
@@ -544,7 +545,7 @@ class AudioRecognizer(
 
         val remoteJob = if(settings.groqApiKey.isNotBlank()) {
             lifecycleScope.async(Dispatchers.IO) {
-                org.futo.voiceinput.shared.groq.GroqWhisperApi.transcribe(floatArray, settings.groqApiKey)
+                org.futo.voiceinput.shared.groq.GroqWhisperApi.transcribe(floatArray, settings.groqApiKey, settings.groqModel)
             }
         } else null
 

--- a/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/RecognizerView.kt
+++ b/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/RecognizerView.kt
@@ -26,7 +26,8 @@ data class RecognizerViewSettings(
     val modelRunConfiguration: MultiModelRunConfiguration,
     val decodingConfiguration: DecodingConfiguration,
     val recordingConfiguration: RecordingSettings,
-    val groqApiKey: String
+    val groqApiKey: String,
+    val groqModel: String
 )
 
 private val VerboseAnnotations = hashMapOf(
@@ -207,7 +208,8 @@ class RecognizerView(
             modelRunConfiguration = settings.modelRunConfiguration,
             decodingConfiguration = settings.decodingConfiguration,
             recordingConfiguration = settings.recordingConfiguration,
-            groqApiKey = settings.groqApiKey
+            groqApiKey = settings.groqApiKey,
+            groqModel = settings.groqModel
         )
     )
 

--- a/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/groq/GroqWhisperApi.kt
+++ b/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/groq/GroqWhisperApi.kt
@@ -40,7 +40,7 @@ object GroqWhisperApi {
         return header.array() + pcmData
     }
 
-    fun transcribe(samples: FloatArray, apiKey: String): String? {
+    fun transcribe(samples: FloatArray, apiKey: String, model: String): String? {
         if(apiKey.isBlank()) return null
         return try {
             val wav = floatArrayToWav(samples)
@@ -60,7 +60,7 @@ object GroqWhisperApi {
             writeString("\r\n")
             writeString("--$boundary\r\n")
             writeString("Content-Disposition: form-data; name=\"model\"\r\n\r\n")
-            writeString("whisper-large-v3\r\n")
+            writeString("$model\r\n")
             writeString("--$boundary--\r\n")
             out.flush()
             out.close()


### PR DESCRIPTION
## Summary
- allow selecting Groq Whisper model from the API settings
- store selected model in DataStore
- propagate the model through voice input settings
- send selected model to Groq API when transcribing

## Testing
- `./gradlew assembleDebug -x lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867a961245c8327b0cf70608dd3a741