### PR TITLE
Add AI reply action using Groq chat

### DIFF
--- a/java/res/values/strings-uix.xml
+++ b/java/res/values/strings-uix.xml
@@ -84,6 +84,11 @@
     <string name="action_clipboard_manager_enable_clipboard_history_button">Enable Clipboard History</string>
     <!-- This message is shown when we're typing in a text field does not support image insertion ("app" refers to the external app that is providing the text field) -->
     <string name="action_clipboard_manager_error_app_image_insertion_unsupported">App does not support image insertion</string>
+
+    <string name="action_ai_reply_title">AI Reply</string>
+    <string name="ai_reply_generate">Generate Reply</string>
+    <string name="ai_reply_insert">Insert</string>
+    <string name="quick_clip_ai_reply">AI Reply</string>
     <string name="action_clipboard_manager_settings_title">Clipboard Manager Settings</string>
     <string name="action_clipboard_manager_settings_hours_to_keep_clips">Hours to keep unpinned clips</string>
     <string name="action_clipboard_manager_settings_maximum_clips">Number of unpinned clips to keep</string>

--- a/java/src/org/futo/inputmethod/latin/uix/QuickClip.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/QuickClip.kt
@@ -35,6 +35,8 @@ import androidx.compose.ui.semantics.role
 import androidx.compose.ui.unit.dp
 import org.futo.inputmethod.latin.R
 import org.futo.inputmethod.latin.uix.theme.Typography
+import org.futo.inputmethod.latin.uix.actions.AiReplyAction
+import org.futo.inputmethod.latin.uix.actions.AiReplyActionHolder
 
 enum class QuickClipKind {
     FullString,
@@ -121,6 +123,21 @@ fun RowScope.QuickClipView(state: QuickClipState, dismiss: () -> Unit) {
     }
 
     LazyRow(Modifier.weight(1.0f)) {
+        state.texts.firstOrNull()?.let { txt ->
+            item {
+                QuickClipPill(
+                    icon = painterResource(R.drawable.text_prediction),
+                    contentDescription = stringResource(R.string.quick_clip_ai_reply),
+                    text = stringResource(R.string.quick_clip_ai_reply),
+                    uri = null
+                ) {
+                    AiReplyActionHolder.pendingText = txt.text
+                    manager!!.activateAction(AiReplyAction)
+                    QuickClip.markQuickClipDismissed()
+                    dismiss()
+                }
+            }
+        }
         state.image?.let { uri ->
             item {
                 QuickClipPill(

--- a/java/src/org/futo/inputmethod/latin/uix/actions/AiReplyAction.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/AiReplyAction.kt
@@ -1,0 +1,68 @@
+package org.futo.inputmethod.latin.uix.actions
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import org.futo.inputmethod.latin.R
+import org.futo.inputmethod.latin.uix.Action
+import org.futo.inputmethod.latin.uix.ActionWindow
+import org.futo.inputmethod.latin.uix.GROQ_API_KEY
+import org.futo.inputmethod.latin.uix.GROQ_MODEL
+import org.futo.inputmethod.latin.uix.KeyboardManagerForAction
+import org.futo.inputmethod.latin.uix.getSetting
+import org.futo.voiceinput.shared.groq.GroqChatApi
+
+private const val DEFAULT_SYSTEM_PROMPT = "You are a helpful assistant that writes concise replies."
+
+private class AiReplyWindow(
+    val manager: KeyboardManagerForAction,
+    val text: String
+) : ActionWindow() {
+    @Composable
+    override fun windowName(): String = stringResource(R.string.action_ai_reply_title)
+
+    @Composable
+    override fun WindowContents(keyboardShown: Boolean) {
+        val context = LocalContext.current
+        val reply = remember { mutableStateOf<String?>(null) }
+        Column(modifier = Modifier.padding(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(text)
+            reply.value?.let { Text(it) }
+            Button(onClick = {
+                val apiKey = context.getSetting(GROQ_API_KEY)
+                val model = context.getSetting(GROQ_MODEL)
+                reply.value = GroqChatApi.chat(DEFAULT_SYSTEM_PROMPT, text, apiKey, model)
+            }, modifier = Modifier.fillMaxWidth()) {
+                Text(stringResource(R.string.ai_reply_generate))
+            }
+            reply.value?.let { r ->
+                Button(onClick = { manager.typeText(r); manager.closeActionWindow() }, modifier = Modifier.fillMaxWidth()) {
+                    Text(stringResource(R.string.ai_reply_insert))
+                }
+            }
+        }
+    }
+}
+
+object AiReplyActionHolder { var pendingText: String = "" }
+
+val AiReplyAction = Action(
+    icon = R.drawable.text_prediction,
+    name = R.string.action_ai_reply_title,
+    simplePressImpl = null,
+    windowImpl = { manager, _ ->
+        val text = AiReplyActionHolder.pendingText
+        AiReplyActionHolder.pendingText = ""
+        AiReplyWindow(manager, text)
+    }
+)

--- a/java/src/org/futo/inputmethod/latin/uix/actions/Registry.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/Registry.kt
@@ -12,6 +12,7 @@ import org.futo.inputmethod.latin.uix.PreferenceUtils
 import org.futo.inputmethod.latin.uix.SettingsKey
 import org.futo.inputmethod.latin.uix.USE_SYSTEM_VOICE_INPUT
 import org.futo.inputmethod.latin.uix.actions.fonttyper.FontTyperAction
+import org.futo.inputmethod.latin.uix.actions.AiReplyAction
 import org.futo.inputmethod.latin.uix.getSetting
 import org.futo.inputmethod.latin.uix.setSettingBlocking
 
@@ -39,7 +40,8 @@ val AllActionsMap = mapOf(
     "down" to ArrowDownAction,
     "left" to ArrowLeftAction,
     "right" to ArrowRightAction,
-    "font_typer" to FontTyperAction
+    "font_typer" to FontTyperAction,
+    "ai_reply" to AiReplyAction
 )
 
 val ActionToId = AllActionsMap.entries.associate { it.value to it.key }

--- a/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/groq/GroqChatApi.kt
+++ b/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/groq/GroqChatApi.kt
@@ -1,0 +1,47 @@
+package org.futo.voiceinput.shared.groq
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.decodeFromString
+import org.futo.voiceinput.shared.util.DebugLogger
+import java.net.HttpURLConnection
+import java.net.URL
+
+object GroqChatApi {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Serializable
+    private data class ChatMessage(val role: String, val content: String)
+    @Serializable
+    private data class ChatRequest(val model: String, val messages: List<ChatMessage>)
+    @Serializable
+    private data class ChatChoice(val message: ChatMessage)
+    @Serializable
+    private data class ChatResponse(val choices: List<ChatChoice>)
+
+    fun chat(systemPrompt: String, userPrompt: String, apiKey: String, model: String): String? {
+        if(apiKey.isBlank()) return null
+        return try {
+            DebugLogger.log("Groq chat start model=$model")
+            val req = ChatRequest(model, listOf(ChatMessage("system", systemPrompt), ChatMessage("user", userPrompt)))
+            val url = URL("https://api.groq.com/openai/v1/chat/completions")
+            val conn = url.openConnection() as HttpURLConnection
+            conn.requestMethod = "POST"
+            conn.doOutput = true
+            conn.setRequestProperty("Authorization", "Bearer $apiKey")
+            conn.setRequestProperty("Content-Type", "application/json")
+            conn.outputStream.use { it.write(json.encodeToString(req).toByteArray()) }
+            if(conn.responseCode != HttpURLConnection.HTTP_OK) {
+                DebugLogger.log("Groq chat failed code=${conn.responseCode}")
+                return null
+            }
+            val resp = conn.inputStream.readBytes().toString(Charsets.UTF_8)
+            val parsed = json.decodeFromString<ChatResponse>(resp)
+            parsed.choices.firstOrNull()?.message?.content
+        } catch(e: Exception) {
+            DebugLogger.log("Groq chat error: ${e.message}")
+            null
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `GroqChatApi` for Groq chat completions
- add `AiReplyAction` to generate reply from clipboard text
- expose new action through QuickClip pill and action registry
- provide new strings for the AI reply feature

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68688d40a0108327a81e7cebd63c2cfd