### PR TITLE
Add AI reply QuickClip option

### DIFF
--- a/java/res/values/strings-talkback-descriptions.xml
+++ b/java/res/values/strings-talkback-descriptions.xml
@@ -196,4 +196,5 @@
     <string name="quick_clip_email_address">Quick clip of an extracted email address: “%s”. Double-tap to paste. Type anything to dismiss.</string>
     <string name="quick_clip_url">Quick clip of an extracted URL: “%s”. Double-tap to paste. Type anything to dismiss.</string>
     <string name="quick_clip_image">Quick image clipboard item. Double-tap to paste image. Type anything to dismiss.</string>
+    <string name="quick_clip_ai_reply">Generate AI reply from clipboard text. Double-tap to insert.</string>
 </resources>

--- a/java/res/values/strings-uix.xml
+++ b/java/res/values/strings-uix.xml
@@ -68,6 +68,7 @@
     <!-- Must be fairly short -->
     <string name="action_clipboard_manager_clear_unpinned_items_button">Clear</string>
     <string name="action_clipboard_manager_clear_clipboard">Clear clipboard</string>
+    <string name="quick_clip_ai_reply_short">AI Reply</string>
     <string name="action_clipboard_manager_error_device_locked_title">Device Locked</string>
     <string name="action_clipboard_manager_error_device_locked_text">Please unlock your device to access clipboard history</string>
     <string name="action_clipboard_manager_error_general_title">Clipboard Error</string>

--- a/java/src/org/futo/inputmethod/latin/uix/ActionBar.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/ActionBar.kt
@@ -1030,6 +1030,7 @@ fun PreviewActionBarWithQuickClip(colorScheme: ThemeOption = DefaultDarkScheme) 
                     QuickClipItem(QuickClipKind.EmailAddress, "keyboard@futo.org", 0),
                     QuickClipItem(QuickClipKind.NumericCode, "123456", 0),
                     QuickClipItem(QuickClipKind.FullString, "Hello world, this is a full string.", 0),
+                    QuickClipItem(QuickClipKind.AiReply, "Hello world, this is a full string.", -1),
                 ),
                 image = "content://example".toUri(),
                 validUntil = Long.MAX_VALUE,

--- a/java/src/org/futo/inputmethod/latin/uix/AiResponder.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/AiResponder.kt
@@ -1,0 +1,14 @@
+package org.futo.inputmethod.latin.uix
+
+import android.content.Context
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.futo.voiceinput.shared.groq.GroqChatApi
+
+suspend fun Context.generateAiReply(text: String, systemPrompt: String = "Reply to the user"): String? {
+    val apiKey = getSetting(GROQ_API_KEY)
+    val model = getSetting(GROQ_MODEL)
+    return withContext(Dispatchers.IO) {
+        GroqChatApi.chat(text, apiKey, model, systemPrompt)
+    }
+}

--- a/java/src/org/futo/inputmethod/latin/uix/QuickClip.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/QuickClip.kt
@@ -21,9 +21,12 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -34,13 +37,15 @@ import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.unit.dp
 import org.futo.inputmethod.latin.R
+import org.futo.inputmethod.latin.uix.generateAiReply
 import org.futo.inputmethod.latin.uix.theme.Typography
 
 enum class QuickClipKind {
     FullString,
     NumericCode,
     EmailAddress,
-    Link
+    Link,
+    AiReply
 }
 
 @get:DrawableRes
@@ -50,6 +55,7 @@ val QuickClipKind.icon: Int get() =
         QuickClipKind.NumericCode -> R.drawable.hash
         QuickClipKind.EmailAddress -> R.drawable.at_sign
         QuickClipKind.Link -> R.drawable.link
+        QuickClipKind.AiReply -> R.drawable.text_prediction
     }
 
 @get:StringRes
@@ -59,6 +65,7 @@ val QuickClipKind.accessibilityDescription: Int get() =
         QuickClipKind.NumericCode -> R.string.quick_clip_numeric_code
         QuickClipKind.EmailAddress -> R.string.quick_clip_email_address
         QuickClipKind.Link -> R.string.quick_clip_url
+        QuickClipKind.AiReply -> R.string.quick_clip_ai_reply
     }
 
 // The order here defines which ones to favor when theres a duplicate
@@ -119,6 +126,8 @@ fun RowScope.QuickClipView(state: QuickClipState, dismiss: () -> Unit) {
     } else {
         null
     }
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
 
     LazyRow(Modifier.weight(1.0f)) {
         state.image?.let { uri ->
@@ -138,31 +147,44 @@ fun RowScope.QuickClipView(state: QuickClipState, dismiss: () -> Unit) {
 
         state.texts.forEach {
             item {
+                val label = it.text.let { txt ->
+                    when(it.kind) {
+                        QuickClipKind.FullString -> if (txt.length > 12) txt.take(10) + "..." else txt
+                        QuickClipKind.NumericCode -> txt
+                        QuickClipKind.EmailAddress -> txt
+                        QuickClipKind.Link -> txt
+                            .replace("http://", "")
+                            .replace("https://", "")
+                            .split("/", limit = 2)
+                            .let { parts ->
+                                if(parts.size == 2)
+                                    parts[0] + "/" + if(parts[1].length > 6) parts[1].take(6) + "..." else parts[1]
+                                else
+                                    parts[0]
+                            }
+                        QuickClipKind.AiReply -> stringResource(R.string.quick_clip_ai_reply_short)
+                    }
+                }
                 QuickClipPill(
                     icon = painterResource(it.kind.icon),
                     contentDescription = stringResource(it.kind.accessibilityDescription, it.text),
-                    text = it.text.let { txt ->
-                        when(it.kind) {
-                            QuickClipKind.FullString -> if (txt.length > 12) txt.take(10) + "..." else txt
-                            QuickClipKind.NumericCode -> txt
-                            QuickClipKind.EmailAddress -> txt
-                            QuickClipKind.Link -> txt
-                                .replace("http://", "")
-                                .replace("https://", "")
-                                .split("/", limit = 2)
-                                .let {
-                                    if(it.size == 2)
-                                        it[0] + "/" + if(it[1].length > 6) it[1].take(6) + "..." else it[1]
-                                    else
-                                        it[0]
-                                }
-                        }
-                    },
+                    text = label,
                     uri = null
                 ) {
-                    manager!!.typeText(it.text)
-                    QuickClip.markQuickClipDismissed()
-                    dismiss()
+                    if(it.kind == QuickClipKind.AiReply) {
+                        lifecycleOwner.lifecycleScope.launch {
+                            val response = context.generateAiReply(it.text)
+                            if(!response.isNullOrBlank()) {
+                                manager?.typeText(response)
+                            }
+                            QuickClip.markQuickClipDismissed()
+                            dismiss()
+                        }
+                    } else {
+                        manager!!.typeText(it.text)
+                        QuickClip.markQuickClipDismissed()
+                        dismiss()
+                    }
                 }
             }
         }
@@ -197,6 +219,13 @@ object QuickClip {
                     }
                 }
             }
+            texts.add(
+                QuickClipItem(
+                    kind = QuickClipKind.AiReply,
+                    text = text,
+                    occurrenceIndex = -1
+                )
+            )
         }
 
         return QuickClipState(

--- a/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/groq/GroqChatApi.kt
+++ b/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/groq/GroqChatApi.kt
@@ -1,0 +1,48 @@
+package org.futo.voiceinput.shared.groq
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import java.net.HttpURLConnection
+import java.net.URL
+
+object GroqChatApi {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Serializable
+    private data class ChatMessage(val role: String, val content: String)
+    @Serializable
+    private data class ChatRequest(val model: String, val messages: List<ChatMessage>)
+    @Serializable
+    private data class ChatChoice(val message: ChatMessage)
+    @Serializable
+    private data class ChatResponse(val choices: List<ChatChoice>)
+
+    fun chat(prompt: String, apiKey: String, model: String, systemPrompt: String): String? {
+        if(apiKey.isBlank()) return null
+        return try {
+            val url = URL("https://api.groq.com/openai/v1/chat/completions")
+            val conn = url.openConnection() as HttpURLConnection
+            conn.requestMethod = "POST"
+            conn.doOutput = true
+            conn.setRequestProperty("Authorization", "Bearer $apiKey")
+            conn.setRequestProperty("Content-Type", "application/json")
+            val req = ChatRequest(
+                model,
+                listOf(
+                    ChatMessage("system", systemPrompt),
+                    ChatMessage("user", prompt)
+                )
+            )
+            val data = json.encodeToString(req).toByteArray(Charsets.UTF_8)
+            conn.outputStream.use { it.write(data) }
+            if(conn.responseCode != HttpURLConnection.HTTP_OK) return null
+            val resp = conn.inputStream.readBytes().toString(Charsets.UTF_8)
+            val parsed = json.decodeFromString<ChatResponse>(resp)
+            parsed.choices.firstOrNull()?.message?.content
+        } catch(e: Exception) {
+            null
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add GroqChatApi for generating chat completions
- add generateAiReply helper
- extend QuickClip with new `AiReply` kind
- support AI replies in QuickClip view and preview
- update talkback descriptions and UI strings

## Testing
- `./gradlew tasks --all` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68688d40a0108327a81e7cebd63c2cfd