### PR TITLE
Integrate groq‑kt for model fetching

### DIFF
--- a/java/src/org/futo/inputmethod/latin/uix/actions/AiReplyAction.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/AiReplyAction.kt
@@ -13,6 +13,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import androidx.compose.runtime.rememberCoroutineScope
 import org.futo.inputmethod.latin.R
 import org.futo.inputmethod.latin.uix.Action
 import org.futo.inputmethod.latin.uix.ActionWindow
@@ -33,15 +37,20 @@ private class AiReplyWindow(
     @Composable
     override fun WindowContents(keyboardShown: Boolean) {
         val context = LocalContext.current
+        val scope = rememberCoroutineScope()
         val reply = remember { mutableStateOf<String?>(null) }
         Column(modifier = Modifier.padding(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
             Text(text)
             reply.value?.let { Text(it) }
             Button(onClick = {
-                val apiKey = context.getSetting(GROQ_API_KEY)
-                val model = context.getSetting(GROQ_CHAT_MODEL)
-                val systemPrompt = context.getSetting(GROQ_CHAT_SYSTEM_PROMPT)
-                reply.value = GroqChatApi.chat(systemPrompt, text, apiKey, model)
+                scope.launch {
+                    val apiKey = context.getSetting(GROQ_API_KEY)
+                    val model = context.getSetting(GROQ_CHAT_MODEL)
+                    val systemPrompt = context.getSetting(GROQ_CHAT_SYSTEM_PROMPT)
+                    reply.value = withContext(Dispatchers.IO) {
+                        GroqChatApi.chat(systemPrompt, text, apiKey, model)
+                    }
+                }
             }, modifier = Modifier.fillMaxWidth()) {
                 Text(stringResource(R.string.ai_reply_generate))
             }

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/AiReply.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/AiReply.kt
@@ -2,14 +2,9 @@ package org.futo.inputmethod.latin.uix.settings.pages
 
 import androidx.compose.runtime.*
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
-import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.futo.inputmethod.latin.R
 import org.futo.inputmethod.latin.uix.GROQ_API_KEY
 import org.futo.inputmethod.latin.uix.GROQ_CHAT_MODEL
@@ -24,7 +19,6 @@ import org.futo.voiceinput.shared.groq.GroqChatApi
 @Composable
 fun AiReplyConfigScreen(navController: NavHostController = rememberNavController()) {
     val context = LocalContext.current
-    val lifecycleOwner = LocalLifecycleOwner.current
     val apiKeyItem = useDataStore(GROQ_API_KEY)
     val modelItem = useDataStore(GROQ_CHAT_MODEL)
     val promptItem = useDataStore(GROQ_CHAT_SYSTEM_PROMPT)
@@ -32,9 +26,7 @@ fun AiReplyConfigScreen(navController: NavHostController = rememberNavController
 
     LaunchedEffect(apiKeyItem.value) {
         if(apiKeyItem.value.isNotBlank()) {
-            val models = withContext(Dispatchers.IO) {
-                GroqChatApi.availableModels(apiKeyItem.value)
-            }
+            val models = GroqChatApi.availableModels(apiKeyItem.value)
             if(!models.isNullOrEmpty()) {
                 modelOptions.value = models
             }

--- a/voiceinput-shared/build.gradle
+++ b/voiceinput-shared/build.gradle
@@ -100,4 +100,6 @@ dependencies {
     implementation(name:'tensorflow-lite-support-api', ext:'aar')
 
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.1'
+    implementation 'io.github.vyfor:groq-kt:0.1.3'
+    implementation 'io.ktor:ktor-client-cio:3.0.0'
 }

--- a/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/groq/GroqChatApi.kt
+++ b/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/groq/GroqChatApi.kt
@@ -5,6 +5,11 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.decodeFromString
 import org.futo.voiceinput.shared.util.DebugLogger
+import io.github.vyfor.groqkt.GroqClient
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.net.HttpURLConnection
 import java.net.URL
 
@@ -49,23 +54,15 @@ object GroqChatApi {
         }
     }
 
-    fun availableModels(apiKey: String): List<String>? {
+    suspend fun availableModels(apiKey: String): List<String>? {
         if(apiKey.isBlank()) return null
         return try {
             DebugLogger.log("Groq chat models fetch")
-            val url = URL("https://api.groq.com/openai/v1/models")
-            val conn = url.openConnection() as HttpURLConnection
-            conn.requestMethod = "GET"
-            conn.setRequestProperty("Authorization", "Bearer $apiKey")
-            conn.connectTimeout = 5000
-            conn.readTimeout = 5000
-            val resp = conn.inputStream.readBytes().toString(Charsets.UTF_8)
-            if(conn.responseCode != HttpURLConnection.HTTP_OK) {
-                DebugLogger.log("Groq chat models failed code=${conn.responseCode}")
-                return null
+            withContext(Dispatchers.IO) {
+                GroqClient(apiKey) { client = HttpClient(CIO) }.use { client ->
+                    client.fetchModels().getOrNull()?.map { it.id }
+                }
             }
-            val parsed = json.decodeFromString<ModelsResponse>(resp)
-            parsed.data.map { it.id }.filter { it.contains("llama") || it.contains("mixtral") || it.contains("gemma") }
         } catch(e: Exception) {
             DebugLogger.log("Groq chat models error: ${e.message}")
             null


### PR DESCRIPTION
## Summary
- adopt the groq‑kt library to fetch chat models
- update dependency list for voiceinput-shared
- load chat models asynchronously in settings
- fix AI reply window to perform network calls off the UI thread

## Testing
- `./gradlew -q :voiceinput-shared:dependencies --configuration compileClasspath` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868b0d22f0c8327befb0ac2d35fb34a