### PR TITLE
Use Ktor for Groq chat model fetch

### DIFF
--- a/java/src/org/futo/inputmethod/latin/uix/actions/AiReplyAction.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/AiReplyAction.kt
@@ -9,10 +9,14 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.futo.inputmethod.latin.R
 import org.futo.inputmethod.latin.uix.Action
 import org.futo.inputmethod.latin.uix.ActionWindow
@@ -33,6 +37,7 @@ private class AiReplyWindow(
     @Composable
     override fun WindowContents(keyboardShown: Boolean) {
         val context = LocalContext.current
+        val scope = rememberCoroutineScope()
         val reply = remember { mutableStateOf<String?>(null) }
         Column(modifier = Modifier.padding(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
             Text(text)
@@ -41,7 +46,12 @@ private class AiReplyWindow(
                 val apiKey = context.getSetting(GROQ_API_KEY)
                 val model = context.getSetting(GROQ_CHAT_MODEL)
                 val systemPrompt = context.getSetting(GROQ_CHAT_SYSTEM_PROMPT)
-                reply.value = GroqChatApi.chat(systemPrompt, text, apiKey, model)
+                scope.launch {
+                    val res = withContext(Dispatchers.IO) {
+                        GroqChatApi.chat(systemPrompt, text, apiKey, model)
+                    }
+                    reply.value = res
+                }
             }, modifier = Modifier.fillMaxWidth()) {
                 Text(stringResource(R.string.ai_reply_generate))
             }

--- a/voiceinput-shared/build.gradle
+++ b/voiceinput-shared/build.gradle
@@ -100,4 +100,7 @@ dependencies {
     implementation(name:'tensorflow-lite-support-api', ext:'aar')
 
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.1'
+
+    implementation 'io.ktor:ktor-client-core:3.2.1'
+    implementation 'io.ktor:ktor-client-okhttp:3.2.1'
 }

--- a/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/groq/GroqChatApi.kt
+++ b/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/groq/GroqChatApi.kt
@@ -5,11 +5,15 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.decodeFromString
 import org.futo.voiceinput.shared.util.DebugLogger
-import java.net.HttpURLConnection
-import java.net.URL
+import io.ktor.client.*
+import io.ktor.client.engine.okhttp.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
 
 object GroqChatApi {
     private val json = Json { ignoreUnknownKeys = true }
+    private val http = HttpClient(OkHttp)
 
     @Serializable
     private data class ChatMessage(val role: String, val content: String)
@@ -24,49 +28,44 @@ object GroqChatApi {
     @Serializable
     data class Model(val id: String)
 
-    fun chat(systemPrompt: String, userPrompt: String, apiKey: String, model: String): String? {
-        if(apiKey.isBlank()) return null
+    suspend fun chat(systemPrompt: String, userPrompt: String, apiKey: String, model: String): String? {
+        if (apiKey.isBlank()) return null
         return try {
             DebugLogger.log("Groq chat start model=$model")
             val req = ChatRequest(model, listOf(ChatMessage("system", systemPrompt), ChatMessage("user", userPrompt)))
-            val url = URL("https://api.groq.com/openai/v1/chat/completions")
-            val conn = url.openConnection() as HttpURLConnection
-            conn.requestMethod = "POST"
-            conn.doOutput = true
-            conn.setRequestProperty("Authorization", "Bearer $apiKey")
-            conn.setRequestProperty("Content-Type", "application/json")
-            conn.outputStream.use { it.write(json.encodeToString(req).toByteArray()) }
-            if(conn.responseCode != HttpURLConnection.HTTP_OK) {
-                DebugLogger.log("Groq chat failed code=${conn.responseCode}")
+            val response = http.post("https://api.groq.com/openai/v1/chat/completions") {
+                header("Authorization", "Bearer $apiKey")
+                contentType(ContentType.Application.Json)
+                setBody(json.encodeToString(req))
+            }
+            if (response.status != HttpStatusCode.OK) {
+                DebugLogger.log("Groq chat failed code=${response.status.value}")
                 return null
             }
-            val resp = conn.inputStream.readBytes().toString(Charsets.UTF_8)
+            val resp = response.bodyAsText()
             val parsed = json.decodeFromString<ChatResponse>(resp)
             parsed.choices.firstOrNull()?.message?.content
-        } catch(e: Exception) {
+        } catch (e: Exception) {
             DebugLogger.log("Groq chat error: ${e.message}")
             null
         }
     }
 
-    fun availableModels(apiKey: String): List<String>? {
-        if(apiKey.isBlank()) return null
+    suspend fun availableModels(apiKey: String): List<String>? {
+        if (apiKey.isBlank()) return null
         return try {
             DebugLogger.log("Groq chat models fetch")
-            val url = URL("https://api.groq.com/openai/v1/models")
-            val conn = url.openConnection() as HttpURLConnection
-            conn.requestMethod = "GET"
-            conn.setRequestProperty("Authorization", "Bearer $apiKey")
-            conn.connectTimeout = 5000
-            conn.readTimeout = 5000
-            val resp = conn.inputStream.readBytes().toString(Charsets.UTF_8)
-            if(conn.responseCode != HttpURLConnection.HTTP_OK) {
-                DebugLogger.log("Groq chat models failed code=${conn.responseCode}")
+            val response = http.get("https://api.groq.com/openai/v1/models") {
+                header("Authorization", "Bearer $apiKey")
+            }
+            if (response.status != HttpStatusCode.OK) {
+                DebugLogger.log("Groq chat models failed code=${response.status.value}")
                 return null
             }
+            val resp = response.bodyAsText()
             val parsed = json.decodeFromString<ModelsResponse>(resp)
             parsed.data.map { it.id }.filter { it.contains("llama") || it.contains("mixtral") || it.contains("gemma") }
-        } catch(e: Exception) {
+        } catch (e: Exception) {
             DebugLogger.log("Groq chat models error: ${e.message}")
             null
         }


### PR DESCRIPTION
## Summary
- integrate Ktor client in shared module
- fetch Groq models with Ktor
- perform chat calls asynchronously
- run reply action inside coroutine

## Testing
- `./gradlew tasks --all` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868b0d22f0c8327befb0ac2d35fb34a