### PR TITLE
Add AI reply test option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,9 @@ You can then open the project in Android Studio and build it that way, or use gr
 ./gradlew assembleUnstableDebug
 ./gradlew assembleStableRelease
 ```
+
+## AI Reply Testing
+
+The Groq API settings screen now includes a **Test AI reply** button. This lets
+you verify that your API key and model work for chat completions before using
+AI Reply in the keyboard.

--- a/java/res/values/strings-uix.xml
+++ b/java/res/values/strings-uix.xml
@@ -511,6 +511,7 @@
     <string name="groq_settings_api_key">Groq API key</string>
     <string name="groq_settings_model">Groq model</string>
     <string name="groq_settings_test">Test connection</string>
+    <string name="groq_settings_test_chat">Test AI reply</string>
     <string name="groq_settings_testing">Testing...</string>
     <string name="groq_settings_success">Success</string>
     <string name="groq_settings_failure">Failed</string>

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/GroqConfig.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/GroqConfig.kt
@@ -20,6 +20,7 @@ import org.futo.inputmethod.latin.uix.settings.SettingTextField
 import org.futo.inputmethod.latin.uix.settings.DropDownPickerSettingItem
 import org.futo.inputmethod.latin.uix.settings.useDataStore
 import org.futo.voiceinput.shared.groq.GroqWhisperApi
+import org.futo.voiceinput.shared.groq.GroqChatApi
 
 @Composable
 fun GroqConfigScreen(navController: NavHostController = rememberNavController()) {
@@ -28,6 +29,7 @@ fun GroqConfigScreen(navController: NavHostController = rememberNavController())
     val apiKeyItem = useDataStore(GROQ_API_KEY)
     val modelItem = useDataStore(GROQ_MODEL)
     val testStatus = remember { mutableStateOf("") }
+    val chatTestStatus = remember { mutableStateOf("") }
     val modelOptions = remember {
         mutableStateOf(listOf("whisper-large-v3", "whisper-large-v3-en", "whisper-large-v3-turbo"))
     }
@@ -74,6 +76,20 @@ fun GroqConfigScreen(navController: NavHostController = rememberNavController())
                         GroqWhisperApi.test(apiKeyItem.value)
                     }
                     testStatus.value = if(success) successText else failureText
+                }
+            }
+        ) { }
+
+        SettingItem(
+            title = stringResource(R.string.groq_settings_test_chat),
+            subtitle = chatTestStatus.value,
+            onClick = {
+                lifecycleOwner.lifecycleScope.launch {
+                    chatTestStatus.value = testing
+                    val success = withContext(Dispatchers.IO) {
+                        GroqChatApi.test(apiKeyItem.value, modelItem.value)
+                    }
+                    chatTestStatus.value = if(success) successText else failureText
                 }
             }
         ) { }

--- a/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/groq/GroqChatApi.kt
+++ b/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/groq/GroqChatApi.kt
@@ -44,4 +44,27 @@ object GroqChatApi {
             null
         }
     }
+
+    fun test(apiKey: String, model: String): Boolean {
+        if(apiKey.isBlank()) return false
+        return try {
+            DebugLogger.log("Groq chat test start model=$model")
+            val req = ChatRequest(model, listOf(ChatMessage("user", "Hello")))
+            val url = URL("https://api.groq.com/openai/v1/chat/completions")
+            val conn = url.openConnection() as HttpURLConnection
+            conn.requestMethod = "POST"
+            conn.doOutput = true
+            conn.setRequestProperty("Authorization", "Bearer $apiKey")
+            conn.setRequestProperty("Content-Type", "application/json")
+            conn.connectTimeout = 5000
+            conn.readTimeout = 5000
+            conn.outputStream.use { it.write(json.encodeToString(req).toByteArray()) }
+            val ok = conn.responseCode == HttpURLConnection.HTTP_OK
+            DebugLogger.log("Groq chat test result code=${conn.responseCode}")
+            ok
+        } catch(e: Exception) {
+            DebugLogger.log("Groq chat test error: ${e.message}")
+            false
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- allow checking Groq chat completions via new test function
- surface test option on the Groq config screen in settings
- update translations for the new button
- document the feature in the README

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869d4d4d3bc8327aa3b66789e922efb