### PR TITLE
Add AI reply testing option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,7 @@ You can then open the project in Android Studio and build it that way, or use gr
 ./gradlew assembleUnstableDebug
 ./gradlew assembleStableRelease
 ```
+
+## Groq AI features
+
+The Groq API settings screen lets you test your configuration. "Test connection" verifies audio transcription, while "Test AI reply" checks chat completions.

--- a/java/res/values/strings-uix.xml
+++ b/java/res/values/strings-uix.xml
@@ -511,6 +511,7 @@
     <string name="groq_settings_api_key">Groq API key</string>
     <string name="groq_settings_model">Groq model</string>
     <string name="groq_settings_test">Test connection</string>
+    <string name="groq_settings_test_chat">Test AI reply</string>
     <string name="groq_settings_testing">Testing...</string>
     <string name="groq_settings_success">Success</string>
     <string name="groq_settings_failure">Failed</string>

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/GroqConfig.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/GroqConfig.kt
@@ -20,6 +20,7 @@ import org.futo.inputmethod.latin.uix.settings.SettingTextField
 import org.futo.inputmethod.latin.uix.settings.DropDownPickerSettingItem
 import org.futo.inputmethod.latin.uix.settings.useDataStore
 import org.futo.voiceinput.shared.groq.GroqWhisperApi
+import org.futo.voiceinput.shared.groq.GroqChatApi
 
 @Composable
 fun GroqConfigScreen(navController: NavHostController = rememberNavController()) {
@@ -28,6 +29,7 @@ fun GroqConfigScreen(navController: NavHostController = rememberNavController())
     val apiKeyItem = useDataStore(GROQ_API_KEY)
     val modelItem = useDataStore(GROQ_MODEL)
     val testStatus = remember { mutableStateOf("") }
+    val testChatStatus = remember { mutableStateOf("") }
     val modelOptions = remember {
         mutableStateOf(listOf("whisper-large-v3", "whisper-large-v3-en", "whisper-large-v3-turbo"))
     }
@@ -63,7 +65,7 @@ fun GroqConfigScreen(navController: NavHostController = rememberNavController())
         val testing = stringResource(R.string.groq_settings_testing)
         val successText = stringResource(R.string.groq_settings_success)
         val failureText = stringResource(R.string.groq_settings_failure)
-        
+
         SettingItem(
             title = stringResource(R.string.groq_settings_test),
             subtitle = testStatus.value,
@@ -74,6 +76,20 @@ fun GroqConfigScreen(navController: NavHostController = rememberNavController())
                         GroqWhisperApi.test(apiKeyItem.value)
                     }
                     testStatus.value = if(success) successText else failureText
+                }
+            }
+        ) { }
+
+        SettingItem(
+            title = stringResource(R.string.groq_settings_test_chat),
+            subtitle = testChatStatus.value,
+            onClick = {
+                lifecycleOwner.lifecycleScope.launch {
+                    testChatStatus.value = testing
+                    val success = withContext(Dispatchers.IO) {
+                        GroqChatApi.chat("test", "hello", apiKeyItem.value, modelItem.value) != null
+                    }
+                    testChatStatus.value = if(success) successText else failureText
                 }
             }
         ) { }


### PR DESCRIPTION
## Summary
- enable testing of the Groq AI chat completion from settings
- add `Test AI reply` string
- document Groq AI features

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869d4d4d3bc8327aa3b66789e922efb