### PR TITLE
Add AI reply test settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ Check out the [FUTO Keyboard website](https://keyboard.futo.org/) for downloads 
 
 The code is licensed under the [FUTO Source First License 1.1](LICENSE.md).
 
+## Features
+
+* Offline-first keyboard with modern features.
+* AI Reply action powered by Groq Chat with a settings test to verify the rewrite feature.
+
 ## Issue tracking and PRs
 
 Please check the GitHub repository to report issues: [https://github.com/futo-org/android-keyboard/](https://github.com/futo-org/android-keyboard/)

--- a/java/res/values/strings-uix.xml
+++ b/java/res/values/strings-uix.xml
@@ -89,6 +89,8 @@
     <string name="ai_reply_generate">Generate Reply</string>
     <string name="ai_reply_insert">Insert</string>
     <string name="quick_clip_ai_reply">AI Reply</string>
+    <string name="ai_reply_settings_title">AI Reply Settings</string>
+    <string name="ai_reply_settings_test">Test AI Reply</string>
     <string name="action_clipboard_manager_settings_title">Clipboard Manager Settings</string>
     <string name="action_clipboard_manager_settings_hours_to_keep_clips">Hours to keep unpinned clips</string>
     <string name="action_clipboard_manager_settings_maximum_clips">Number of unpinned clips to keep</string>

--- a/java/src/org/futo/inputmethod/latin/uix/actions/AiReplyAction.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/AiReplyAction.kt
@@ -21,6 +21,7 @@ import org.futo.inputmethod.latin.uix.GROQ_MODEL
 import org.futo.inputmethod.latin.uix.KeyboardManagerForAction
 import org.futo.inputmethod.latin.uix.getSetting
 import org.futo.voiceinput.shared.groq.GroqChatApi
+import org.futo.inputmethod.latin.uix.settings.pages.AiReplySettingsMenu
 
 private const val DEFAULT_SYSTEM_PROMPT = "You are a helpful assistant that writes concise replies."
 
@@ -64,5 +65,6 @@ val AiReplyAction = Action(
         val text = AiReplyActionHolder.pendingText
         AiReplyActionHolder.pendingText = ""
         AiReplyWindow(manager, text)
-    }
+    },
+    settingsMenu = AiReplySettingsMenu
 )

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/AiReplyConfig.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/AiReplyConfig.kt
@@ -1,0 +1,53 @@
+package org.futo.inputmethod.latin.uix.settings.pages
+
+import androidx.compose.runtime.*
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.res.stringResource
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.futo.inputmethod.latin.R
+import org.futo.inputmethod.latin.uix.GROQ_API_KEY
+import org.futo.inputmethod.latin.uix.GROQ_MODEL
+import org.futo.inputmethod.latin.uix.settings.UserSetting
+import org.futo.inputmethod.latin.uix.settings.UserSettingsMenu
+import org.futo.inputmethod.latin.uix.settings.SettingItem
+import org.futo.inputmethod.latin.uix.settings.useDataStore
+import org.futo.voiceinput.shared.groq.GroqChatApi
+
+val AiReplySettingsMenu = UserSettingsMenu(
+    title = R.string.ai_reply_settings_title,
+    navPath = "actions/ai_reply",
+    registerNavPath = true,
+    settings = listOf(
+        UserSetting(name = R.string.ai_reply_settings_test) {
+            val lifecycleOwner = LocalLifecycleOwner.current
+            val apiKeyItem = useDataStore(GROQ_API_KEY)
+            val modelItem = useDataStore(GROQ_MODEL)
+            val testStatus = remember { mutableStateOf("") }
+            val testing = stringResource(R.string.groq_settings_testing)
+            val successText = stringResource(R.string.groq_settings_success)
+            val failureText = stringResource(R.string.groq_settings_failure)
+
+            SettingItem(
+                title = stringResource(R.string.ai_reply_settings_test),
+                subtitle = testStatus.value,
+                onClick = {
+                    lifecycleOwner.lifecycleScope.launch {
+                        testStatus.value = testing
+                        val success = withContext(Dispatchers.IO) {
+                            GroqChatApi.chat(
+                                "You are a helpful assistant that writes concise replies.",
+                                "Hello",
+                                apiKeyItem.value,
+                                modelItem.value
+                            ) != null
+                        }
+                        testStatus.value = if (success) successText else failureText
+                    }
+                }
+            ) { }
+        }
+    )
+)


### PR DESCRIPTION
## Summary
- introduce AI reply settings screen with a test button
- connect AiReply action to the new settings menu
- document AI reply test in README
- add strings for AI reply settings

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869d4d4d3bc8327aa3b66789e922efb