### PR TITLE
Add AI reply test settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Due to custom license, pull requests to this repository require signing a [CLA](
 
 If you want to contribute layouts, check out the [layouts repo](https://github.com/futo-org/futo-keyboard-layouts).
 
+## AI Features
+
+The keyboard integrates optional Groq-based AI services. You can test your API key for both voice input and AI reply in the settings. The AI reply section now includes a button to verify that the rewrite service works.
+
 ## Building
 
 When cloning the repository, you must perform a recursive clone to fetch all dependencies:

--- a/java/res/values/strings-uix.xml
+++ b/java/res/values/strings-uix.xml
@@ -89,6 +89,11 @@
     <string name="ai_reply_generate">Generate Reply</string>
     <string name="ai_reply_insert">Insert</string>
     <string name="quick_clip_ai_reply">AI Reply</string>
+    <string name="ai_reply_settings_title">AI Reply</string>
+    <string name="ai_reply_settings_test">Test rewrite</string>
+    <string name="ai_reply_settings_testing">Testing...</string>
+    <string name="ai_reply_settings_success">Success</string>
+    <string name="ai_reply_settings_failure">Failed</string>
     <string name="action_clipboard_manager_settings_title">Clipboard Manager Settings</string>
     <string name="action_clipboard_manager_settings_hours_to_keep_clips">Hours to keep unpinned clips</string>
     <string name="action_clipboard_manager_settings_maximum_clips">Number of unpinned clips to keep</string>

--- a/java/src/org/futo/inputmethod/latin/uix/actions/AiReplyAction.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/AiReplyAction.kt
@@ -7,8 +7,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -20,9 +18,20 @@ import org.futo.inputmethod.latin.uix.GROQ_API_KEY
 import org.futo.inputmethod.latin.uix.GROQ_MODEL
 import org.futo.inputmethod.latin.uix.KeyboardManagerForAction
 import org.futo.inputmethod.latin.uix.getSetting
+import org.futo.inputmethod.latin.uix.settings.UserSettingsMenu
+import org.futo.inputmethod.latin.uix.settings.UserSetting
+import org.futo.inputmethod.latin.uix.settings.SettingItem
+import org.futo.inputmethod.latin.uix.settings.useDataStore
 import org.futo.voiceinput.shared.groq.GroqChatApi
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
-private const val DEFAULT_SYSTEM_PROMPT = "You are a helpful assistant that writes concise replies."
+internal const val DEFAULT_SYSTEM_PROMPT = "You are a helpful assistant that writes concise replies."
 
 private class AiReplyWindow(
     val manager: KeyboardManagerForAction,
@@ -64,5 +73,36 @@ val AiReplyAction = Action(
         val text = AiReplyActionHolder.pendingText
         AiReplyActionHolder.pendingText = ""
         AiReplyWindow(manager, text)
-    }
+    },
+    settingsMenu = UserSettingsMenu(
+        title = R.string.ai_reply_settings_title,
+        navPath = "actions/ai_reply",
+        registerNavPath = true,
+        settings = listOf(
+            UserSetting(name = R.string.ai_reply_settings_test) {
+                val lifecycleOwner = LocalLifecycleOwner.current
+                val apiKeyItem = useDataStore(GROQ_API_KEY)
+                val modelItem = useDataStore(GROQ_MODEL)
+                val status = remember { mutableStateOf("") }
+
+                val testing = stringResource(R.string.ai_reply_settings_testing)
+                val successText = stringResource(R.string.ai_reply_settings_success)
+                val failureText = stringResource(R.string.ai_reply_settings_failure)
+
+                SettingItem(
+                    title = stringResource(R.string.ai_reply_settings_test),
+                    subtitle = status.value,
+                    onClick = {
+                        lifecycleOwner.lifecycleScope.launch {
+                            status.value = testing
+                            val success = withContext(Dispatchers.IO) {
+                                GroqChatApi.chat(DEFAULT_SYSTEM_PROMPT, "Rewrite this text.", apiKeyItem.value, modelItem.value) != null
+                            }
+                            status.value = if (success) successText else failureText
+                        }
+                    }
+                ) { }
+            }
+        )
+    )
 )

--- a/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/groq/GroqChatApi.kt
+++ b/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/groq/GroqChatApi.kt
@@ -44,4 +44,24 @@ object GroqChatApi {
             null
         }
     }
+
+    fun test(apiKey: String): Boolean {
+        if(apiKey.isBlank()) return false
+        return try {
+            DebugLogger.log("Groq chat test start")
+            val url = URL("https://api.groq.com/openai/v1/models")
+            val conn = url.openConnection() as HttpURLConnection
+            conn.requestMethod = "GET"
+            conn.setRequestProperty("Authorization", "Bearer $apiKey")
+            conn.connectTimeout = 5000
+            conn.readTimeout = 5000
+            conn.inputStream.use { it.readBytes() }
+            val ok = conn.responseCode == HttpURLConnection.HTTP_OK
+            DebugLogger.log("Groq chat test result code=${conn.responseCode}")
+            ok
+        } catch(e: Exception) {
+            DebugLogger.log("Groq chat test error: ${e.message}")
+            false
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- allow testing AI rewrite via new AI Reply settings
- expose `test` method in `GroqChatApi`
- document AI features in README

## Testing
- `./gradlew lint --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869d4d4d3bc8327aa3b66789e922efb