### PR TITLE
Add AI reply test option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,15 @@ You can then open the project in Android Studio and build it that way, or use gr
 ./gradlew assembleUnstableDebug
 ./gradlew assembleStableRelease
 ```
+
+## AI Reply Testing
+
+The Groq API settings screen now includes a **Test AI reply** button. This lets
+you verify that your API key and model work for chat completions before using
+AI Reply in the keyboard. Behind the scenes the keyboard automatically queries
+`https://api.groq.com/openai/v1/models` to pick a suitable model if your
+preferred one isn't available. See [Groq's docs](https://console.groq.com/docs/)
+for details on supported models.
+
+The Settings home page now places the **Search** button at the bottom with a
+border so it’s easier to find.

--- a/java/res/values/strings-uix.xml
+++ b/java/res/values/strings-uix.xml
@@ -511,6 +511,7 @@
     <string name="groq_settings_api_key">Groq API key</string>
     <string name="groq_settings_model">Groq model</string>
     <string name="groq_settings_test">Test connection</string>
+    <string name="groq_settings_test_chat">Test AI reply</string>
     <string name="groq_settings_testing">Testing...</string>
     <string name="groq_settings_success">Success</string>
     <string name="groq_settings_failure">Failed</string>

--- a/java/src/org/futo/inputmethod/latin/uix/actions/AiReplyAction.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/AiReplyAction.kt
@@ -40,7 +40,8 @@ private class AiReplyWindow(
             reply.value?.let { Text(it) }
             Button(onClick = {
                 val apiKey = context.getSetting(GROQ_API_KEY)
-                val model = context.getSetting(GROQ_MODEL)
+                val pref = context.getSetting(GROQ_MODEL)
+                val model = GroqChatApi.pickGroqModel(apiKey, pref)
                 reply.value = GroqChatApi.chat(DEFAULT_SYSTEM_PROMPT, text, apiKey, model)
             }, modifier = Modifier.fillMaxWidth()) {
                 Text(stringResource(R.string.ai_reply_generate))

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/GroqConfig.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/GroqConfig.kt
@@ -20,6 +20,7 @@ import org.futo.inputmethod.latin.uix.settings.SettingTextField
 import org.futo.inputmethod.latin.uix.settings.DropDownPickerSettingItem
 import org.futo.inputmethod.latin.uix.settings.useDataStore
 import org.futo.voiceinput.shared.groq.GroqWhisperApi
+import org.futo.voiceinput.shared.groq.GroqChatApi
 
 @Composable
 fun GroqConfigScreen(navController: NavHostController = rememberNavController()) {
@@ -28,6 +29,7 @@ fun GroqConfigScreen(navController: NavHostController = rememberNavController())
     val apiKeyItem = useDataStore(GROQ_API_KEY)
     val modelItem = useDataStore(GROQ_MODEL)
     val testStatus = remember { mutableStateOf("") }
+    val chatTestStatus = remember { mutableStateOf("") }
     val modelOptions = remember {
         mutableStateOf(listOf("whisper-large-v3", "whisper-large-v3-en", "whisper-large-v3-turbo"))
     }
@@ -74,6 +76,23 @@ fun GroqConfigScreen(navController: NavHostController = rememberNavController())
                         GroqWhisperApi.test(apiKeyItem.value)
                     }
                     testStatus.value = if(success) successText else failureText
+                }
+            }
+        ) { }
+
+        SettingItem(
+            title = stringResource(R.string.groq_settings_test_chat),
+            subtitle = chatTestStatus.value,
+            onClick = {
+                lifecycleOwner.lifecycleScope.launch {
+                    chatTestStatus.value = testing
+                    val model = withContext(Dispatchers.IO) {
+                        GroqChatApi.pickGroqModel(apiKeyItem.value, modelItem.value)
+                    }
+                    val success = withContext(Dispatchers.IO) {
+                        GroqChatApi.test(apiKeyItem.value, model)
+                    }
+                    chatTestStatus.value = if(success) successText else failureText
                 }
             }
         ) { }

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/Home.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/Home.kt
@@ -13,7 +13,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -165,19 +165,13 @@ fun HomeScreen(navController: NavHostController = rememberNavController()) {
         ) {
             Spacer(modifier = Modifier.height(24.dp))
             Row(Modifier.padding(16.dp)) {
-                Text(stringResource(R.string.english_ime_settings), style = Typography.Heading.Medium, modifier = Modifier
-                    .align(CenterVertically)
-                    .weight(1.0f))
-
-                Spacer(Modifier.width(4.dp))
-
-                IconButton(onClick = {
-                    navController.navigate("search")
-                }) {
-                    Icon(Icons.Default.Search, contentDescription = stringResource(
-                        R.string.settings_search_menu_title
-                    ))
-                }
+                Text(
+                    stringResource(R.string.english_ime_settings),
+                    style = Typography.Heading.Medium,
+                    modifier = Modifier
+                        .align(CenterVertically)
+                        .weight(1.0f)
+                )
             }
 
             ConditionalMigrateUpdateNotice()
@@ -204,6 +198,19 @@ fun HomeScreen(navController: NavHostController = rememberNavController()) {
                 modifier = Modifier.fillMaxWidth(),
                 textAlign = TextAlign.Center
             )
+            Spacer(modifier = Modifier.height(16.dp))
+
+            OutlinedButton(
+                onClick = { navController.navigate("search") },
+                modifier = Modifier
+                    .padding(horizontal = 16.dp)
+                    .fillMaxWidth()
+            ) {
+                Icon(Icons.Default.Search, contentDescription = null)
+                Spacer(Modifier.width(8.dp))
+                Text(stringResource(R.string.settings_search_menu_title))
+            }
+
             Spacer(modifier = Modifier.height(32.dp))
         }
         TextButton(onClick = {

--- a/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/groq/GroqChatApi.kt
+++ b/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/groq/GroqChatApi.kt
@@ -4,12 +4,48 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.decodeFromString
+import org.json.JSONObject
 import org.futo.voiceinput.shared.util.DebugLogger
 import java.net.HttpURLConnection
 import java.net.URL
+import java.nio.charset.Charsets
 
 object GroqChatApi {
     private val json = Json { ignoreUnknownKeys = true }
+
+    /**
+     * Returns a model that definitely exists on Groq.
+     * If [preferredId] is available it is used, otherwise a recommended
+     * fallback is selected.
+     */
+    fun pickGroqModel(apiKey: String, preferredId: String = "llama3-70b-8192"): String {
+        return try {
+            val url = URL("https://api.groq.com/openai/v1/models")
+            val conn = url.openConnection() as HttpURLConnection
+            conn.requestMethod = "GET"
+            conn.setRequestProperty("Authorization", "Bearer $apiKey")
+            conn.connectTimeout = 5000
+            conn.readTimeout = 5000
+            val resp = conn.inputStream.readBytes().toString(Charsets.UTF_8)
+            if(conn.responseCode != HttpURLConnection.HTTP_OK) {
+                return "llama-3.1-8b-instant"
+            }
+            val data = JSONObject(resp).getJSONArray("data")
+            val ids = mutableSetOf<String>()
+            for(i in 0 until data.length()) {
+                ids.add(data.getJSONObject(i).getString("id"))
+            }
+            when {
+                preferredId in ids -> preferredId
+                "llama-3.3-70b-versatile" in ids -> "llama-3.3-70b-versatile"
+                "llama-3.1-8b-instant" in ids -> "llama-3.1-8b-instant"
+                else -> ids.first()
+            }
+        } catch(e: Exception) {
+            DebugLogger.log("Groq pick model error: ${e.message}")
+            "llama-3.1-8b-instant"
+        }
+    }
 
     @Serializable
     private data class ChatMessage(val role: String, val content: String)
@@ -42,6 +78,71 @@ object GroqChatApi {
         } catch(e: Exception) {
             DebugLogger.log("Groq chat error: ${e.message}")
             null
+        }
+    }
+
+    /**
+     * Streams a reply token by token. This will automatically pick a valid model
+     * if [preferredModel] is unavailable.
+     */
+    fun stream(prompt: String, apiKey: String, preferredModel: String = "llama3-70b-8192", onToken: (String) -> Unit) {
+        if(apiKey.isBlank()) return
+        val model = pickGroqModel(apiKey, preferredModel)
+        val reqBody = """
+          {
+            "model":"$model",
+            "stream":true,
+            "messages":[{"role":"user","content":"$prompt"}]
+          }
+        """.trimIndent()
+
+        try {
+            val url = URL("https://api.groq.com/openai/v1/chat/completions")
+            val conn = url.openConnection() as HttpURLConnection
+            conn.requestMethod = "POST"
+            conn.doOutput = true
+            conn.setRequestProperty("Authorization", "Bearer $apiKey")
+            conn.setRequestProperty("Content-Type", "application/json")
+            conn.setRequestProperty("Accept", "text/event-stream")
+            conn.outputStream.use { it.write(reqBody.toByteArray()) }
+            conn.inputStream.bufferedReader().useLines { lines ->
+                lines.forEach { line ->
+                    if(!line.startsWith("data:")) return@forEach
+                    val payload = line.removePrefix("data:").trim()
+                    if(payload == "[DONE]") return
+                    val token = JSONObject(payload)
+                        .getJSONArray("choices")
+                        .getJSONObject(0)
+                        .getJSONObject("delta")
+                        .optString("content")
+                    if(token.isNotEmpty()) onToken(token)
+                }
+            }
+        } catch(e: Exception) {
+            DebugLogger.log("Groq chat stream error: ${e.message}")
+        }
+    }
+
+    fun test(apiKey: String, model: String): Boolean {
+        if(apiKey.isBlank()) return false
+        return try {
+            DebugLogger.log("Groq chat test start model=$model")
+            val req = ChatRequest(model, listOf(ChatMessage("user", "Hello")))
+            val url = URL("https://api.groq.com/openai/v1/chat/completions")
+            val conn = url.openConnection() as HttpURLConnection
+            conn.requestMethod = "POST"
+            conn.doOutput = true
+            conn.setRequestProperty("Authorization", "Bearer $apiKey")
+            conn.setRequestProperty("Content-Type", "application/json")
+            conn.connectTimeout = 5000
+            conn.readTimeout = 5000
+            conn.outputStream.use { it.write(json.encodeToString(req).toByteArray()) }
+            val ok = conn.responseCode == HttpURLConnection.HTTP_OK
+            DebugLogger.log("Groq chat test result code=${conn.responseCode}")
+            ok
+        } catch(e: Exception) {
+            DebugLogger.log("Groq chat test error: ${e.message}")
+            false
         }
     }
 }


### PR DESCRIPTION
## Summary
- allow checking Groq chat completions via new test function
- surface test option on the Groq config screen in settings
- move settings search button to bottom with border
- use Groq model picker and streaming API
- document new model selection and search button in README

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869d4d4d3bc8327aa3b66789e922efb