### PR TITLE
Move search icon to bottom of settings screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ The goal is to make a good modern keyboard that stays offline and doesn't spy on
 
 Check out the [FUTO Keyboard website](https://keyboard.futo.org/) for downloads and more information.
 
+## Features
+
+- Offline-first keyboard with privacy-focused design.
+- New settings search button is located at the bottom of the settings screen with an animated border for easier discovery.
+
 The code is licensed under the [FUTO Source First License 1.1](LICENSE.md).
 
 ## Issue tracking and PRs

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/Home.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/Home.kt
@@ -10,13 +10,21 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.clickable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateColor
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.border
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberInfiniteTransition
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
@@ -164,21 +172,13 @@ fun HomeScreen(navController: NavHostController = rememberNavController()) {
                 .verticalScroll(scrollState)
         ) {
             Spacer(modifier = Modifier.height(24.dp))
-            Row(Modifier.padding(16.dp)) {
-                Text(stringResource(R.string.english_ime_settings), style = Typography.Heading.Medium, modifier = Modifier
-                    .align(CenterVertically)
-                    .weight(1.0f))
-
-                Spacer(Modifier.width(4.dp))
-
-                IconButton(onClick = {
-                    navController.navigate("search")
-                }) {
-                    Icon(Icons.Default.Search, contentDescription = stringResource(
-                        R.string.settings_search_menu_title
-                    ))
-                }
-            }
+            Text(
+                stringResource(R.string.english_ime_settings),
+                style = Typography.Heading.Medium,
+                modifier = Modifier
+                    .padding(horizontal = 16.dp)
+                    .fillMaxWidth()
+            )
 
             ConditionalMigrateUpdateNotice()
             ConditionalUnpaidNoticeWithNav(navController)
@@ -186,6 +186,33 @@ fun HomeScreen(navController: NavHostController = rememberNavController()) {
             HomeScreenLite.render(showTitle = false)
 
 
+            Spacer(modifier = Modifier.height(16.dp))
+
+            val infiniteTransition = rememberInfiniteTransition()
+            val borderColor by infiniteTransition.animateColor(
+                initialValue = MaterialTheme.colorScheme.primary,
+                targetValue = MaterialTheme.colorScheme.primary.copy(alpha = 0.2f),
+                animationSpec = infiniteRepeatable(
+                    animation = tween(durationMillis = 1000),
+                    repeatMode = RepeatMode.Reverse
+                )
+            )
+
+            Row(
+                modifier = Modifier
+                    .padding(horizontal = 16.dp)
+                    .border(2.dp, borderColor, RoundedCornerShape(8.dp))
+                    .clickable { navController.navigate("search") }
+                    .padding(horizontal = 12.dp, vertical = 8.dp)
+                    .fillMaxWidth(),
+                verticalAlignment = CenterVertically
+            ) {
+                Icon(Icons.Default.Search, contentDescription = stringResource(
+                    R.string.settings_search_menu_title
+                ))
+                Spacer(Modifier.width(8.dp))
+                Text(stringResource(R.string.settings_search_menu_title), style = Typography.Heading.Medium)
+            }
             Spacer(modifier = Modifier.height(16.dp))
 
             if(isPaid || LocalInspectionMode.current) {


### PR DESCRIPTION
## Summary
- highlight settings search by moving it to the bottom and adding an animated border
- document new search location in README

## Testing
- `./gradlew tasks --all` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a5e9930c4832796f2eab1a4274bfb