### PR TITLE
Fix compose animation dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,12 +10,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Check out the [FUTO Keyboard website](https://keyboard.futo.org/) for downloads 
 ## Features
 
 - Offline-first keyboard with privacy-focused design.
-- New settings search button is located at the bottom of the settings screen with an animated border for easier discovery.
+- New settings search button is located at the bottom of the settings screen with an animated border powered by Compose for easier discovery.
 
 The code is licensed under the [FUTO Source First License 1.1](LICENSE.md).
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Check out the [FUTO Keyboard website](https://keyboard.futo.org/) for downloads 
 ## Features
 
 - Offline-first keyboard with privacy-focused design.
-- New settings search button is located at the bottom of the settings screen with an animated border powered by Compose for easier discovery.
+- New settings search button at the bottom of the settings screen uses an infinite animated border powered by Compose for easier discovery.
 
 The code is licensed under the [FUTO Source First License 1.1](LICENSE.md).
 

--- a/build.gradle
+++ b/build.gradle
@@ -287,6 +287,7 @@ dependencies {
     implementation 'androidx.compose.ui:ui'
     implementation 'androidx.compose.ui:ui-graphics'
     implementation 'androidx.compose.animation:animation'
+    implementation 'androidx.compose.animation:animation-core'
     implementation 'androidx.compose.ui:ui-tooling-preview'
     implementation 'androidx.compose.material3:material3'
     implementation 'com.google.android.material:material:1.12.0'

--- a/build.gradle
+++ b/build.gradle
@@ -286,6 +286,7 @@ dependencies {
     implementation platform('androidx.compose:compose-bom:2024.06.00')
     implementation 'androidx.compose.ui:ui'
     implementation 'androidx.compose.ui:ui-graphics'
+    implementation 'androidx.compose.animation:animation'
     implementation 'androidx.compose.ui:ui-tooling-preview'
     implementation 'androidx.compose.material3:material3'
     implementation 'com.google.android.material:material:1.12.0'

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/Home.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/Home.kt
@@ -24,7 +24,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberInfiniteTransition
+import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier


### PR DESCRIPTION
## Summary
- add Compose animation dependency to fix unresolved reference errors
- update GitHub workflow to use checkout/setup-java v4
- note Compose-driven search button animation in README

## Testing
- `./gradlew assembleStableDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a6ad43b888327ba1f8491b2d47d8f