### PR TITLE
Use coroutine scope in AiReplyAction

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Check out the [FUTO Keyboard website](https://keyboard.futo.org/) for downloads 
 - Offline-first keyboard with privacy-focused design.
 - New settings search button at the bottom of the settings screen highlights itself with a smooth repeating border animation for easier discovery.
 - AI Reply menu for configuring Groq-powered quick replies.
+- AI reply generation now streams responses using coroutines for smoother updates.
 
 The code is licensed under the [FUTO Source First License 1.1](LICENSE.md).
 

--- a/java/src/org/futo/inputmethod/latin/uix/actions/AiReplyAction.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/AiReplyAction.kt
@@ -47,9 +47,9 @@ private class AiReplyWindow(
                 val apiKey = context.getSetting(GROQ_API_KEY)
                 coroutineScope.launch(Dispatchers.IO) {
                     try {
-                        reply.value = ""
+                        withContext(Dispatchers.Main) { reply.value = "" }
                         stream(apiKey, text) { token ->
-                            withContext(Dispatchers.Main) {
+                            coroutineScope.launch(Dispatchers.Main) {
                                 reply.value = (reply.value ?: "") + token
                             }
                         }


### PR DESCRIPTION
## Summary
- use `rememberCoroutineScope` in `AiReplyAction` window
- launch coroutine on `Dispatchers.IO` and update reply text on main thread
- show `Toast` on error

## Testing
- `./gradlew test --no-daemon` *(fails: LicenceNotAcceptedException)*

------
https://chatgpt.com/codex/tasks/task_e_686b42211fe88327ad734b5434c5b9b1