### PR TITLE
Send clipboard and prompt to Groq

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Check out the [FUTO Keyboard website](https://keyboard.futo.org/) for downloads 
 
 - Offline-first keyboard with privacy-focused design.
 - Settings search bar integrated into the settings screen with a helpful "Settings search or try typing here." placeholder. The field grows to fit long queries.
+- Most extra features, such as Quick Switch, can be enabled or disabled from the settings.
 - AMOLED friendly dark themes with purple, red, blue, and green accents for battery savings.
 - AI Reply menu for configuring Groq-powered quick replies using chat completion models fetched from Groq.
 - AI Reply prompt can be customized from the keyboard or settings and the clipboard text is sent to Groq for context.
@@ -16,7 +17,7 @@ Check out the [FUTO Keyboard website](https://keyboard.futo.org/) for downloads 
 - New settings search button at the bottom of the settings screen highlights itself with a smooth repeating border animation for easier discovery.
 - AI Reply menu for configuring Groq-powered quick replies.
 - AI reply generation now streams responses using coroutines for smoother updates.
-- Quick Switch action uses an accessibility service to jump to your previously used app.
+- Quick Switch can be toggled in settings and uses an accessibility service to jump to your previously used app.
 
 The code is licensed under the [FUTO Source First License 1.1](LICENSE.md).
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Check out the [FUTO Keyboard website](https://keyboard.futo.org/) for downloads 
 - AI Reply menu for configuring Groq-powered quick replies using chat completion models fetched from Groq.
 - AI Reply prompt can be customized from the keyboard or settings and the clipboard text is sent to Groq for context.
 - Voice recognition output is normalized so repeated words are removed.
+- Voice input respects the keyboard's caps lock state.
 - New settings search button at the bottom of the settings screen highlights itself with a smooth repeating border animation for easier discovery.
 - AI Reply menu for configuring Groq-powered quick replies.
 - AI reply generation now streams responses using coroutines for smoother updates.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Check out the [FUTO Keyboard website](https://keyboard.futo.org/) for downloads 
 - New settings search button at the bottom of the settings screen highlights itself with a smooth repeating border animation for easier discovery.
 - AI Reply menu for configuring Groq-powered quick replies.
 - AI reply generation now streams responses using coroutines for smoother updates.
+- Quick Switch action uses an accessibility service to jump to your previously used app.
 
 The code is licensed under the [FUTO Source First License 1.1](LICENSE.md).
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Check out the [FUTO Keyboard website](https://keyboard.futo.org/) for downloads 
 - Settings search bar integrated into the settings screen with a helpful "Settings search or try typing here." placeholder. The field grows to fit long queries.
 - AMOLED friendly dark themes with purple, red, blue, and green accents for battery savings.
 - AI Reply menu for configuring Groq-powered quick replies using chat completion models fetched from Groq.
+- AI Reply prompt can be customized from the keyboard or settings and the clipboard text is sent to Groq for context.
 - Voice recognition output is normalized so repeated words are removed.
 - New settings search button at the bottom of the settings screen highlights itself with a smooth repeating border animation for easier discovery.
 - AI Reply menu for configuring Groq-powered quick replies.

--- a/java/AndroidManifest.xml
+++ b/java/AndroidManifest.xml
@@ -195,6 +195,17 @@
             android:name=".content.KbContentProvider"
             android:exported="false"
             android:grantUriPermissions="true" />
+
+        <service
+            android:name=".uix.services.QuickSwitchService"
+            android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.accessibilityservice.AccessibilityService" />
+            </intent-filter>
+            <meta-data android:name="android.accessibilityservice"
+                android:resource="@xml/quick_switch_service" />
+        </service>
     </application>
 
     <!-- To query enabled input methods for voice IME detection -->

--- a/java/res/values/strings-uix.xml
+++ b/java/res/values/strings-uix.xml
@@ -10,6 +10,7 @@
     <string name="action_redo_title">Redo</string>
     <string name="action_switch_apps_title">Switch Apps</string>
     <string name="action_switch_apps_enable_service">Enable accessibility service to use Switch Apps</string>
+    <string name="switch_apps_enable">Enable Quick Switch action</string>
     <string name="action_text_editor_title">Text Editor</string>
     <string name="action_debug_title">Debug Info</string>
     <string name="action_more_actions_title">All Actions</string>

--- a/java/res/values/strings-uix.xml
+++ b/java/res/values/strings-uix.xml
@@ -8,6 +8,8 @@
     <string name="action_paste_title">Paste from Clipboard</string>
     <string name="action_undo_title">Undo</string>
     <string name="action_redo_title">Redo</string>
+    <string name="action_switch_apps_title">Switch Apps</string>
+    <string name="action_switch_apps_enable_service">Enable accessibility service to use Switch Apps</string>
     <string name="action_text_editor_title">Text Editor</string>
     <string name="action_debug_title">Debug Info</string>
     <string name="action_more_actions_title">All Actions</string>

--- a/java/res/values/strings-uix.xml
+++ b/java/res/values/strings-uix.xml
@@ -516,6 +516,8 @@
     <string name="ai_reply_enable">Enable AI Reply</string>
     <string name="ai_reply_groq_config">Groq API Settings</string>
     <string name="ai_reply_groq_config_subtitle">Configure Groq API key and model</string>
+    <string name="ai_reply_prompt_title">AI Reply Prompt</string>
+    <string name="ai_reply_prompt_placeholder">e.g. Write a short helpful reply</string>
 
     <string name="groq_settings_title">Groq API</string>
     <string name="groq_settings_api_key">Groq API key</string>

--- a/java/res/xml/quick_switch_service.xml
+++ b/java/res/xml/quick_switch_service.xml
@@ -1,0 +1,5 @@
+<accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:accessibilityEventTypes="typeWindowStateChanged"
+    android:accessibilityFeedbackType="feedbackGeneric"
+    android:canRetrieveWindowContent="false"
+    android:accessibilityFlags="flagDefault" />

--- a/java/src/org/futo/inputmethod/latin/uix/AiReplySettingKeys.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/AiReplySettingKeys.kt
@@ -1,8 +1,14 @@
 package org.futo.inputmethod.latin.uix
 
 import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
 
 val ENABLE_AI_REPLY = SettingsKey(
     key = booleanPreferencesKey("enable_ai_reply"),
     default = true
+)
+
+val AI_REPLY_PROMPT = SettingsKey(
+    key = stringPreferencesKey("ai_reply_prompt"),
+    default = "Write a short helpful reply"
 )

--- a/java/src/org/futo/inputmethod/latin/uix/AiReplySettingKeys.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/AiReplySettingKeys.kt
@@ -12,3 +12,8 @@ val AI_REPLY_PROMPT = SettingsKey(
     key = stringPreferencesKey("ai_reply_prompt"),
     default = "Write a short helpful reply"
 )
+
+val ENABLE_SWITCH_APPS = SettingsKey(
+    key = booleanPreferencesKey("enable_switch_apps"),
+    default = true
+)

--- a/java/src/org/futo/inputmethod/latin/uix/actions/Registry.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/Registry.kt
@@ -12,6 +12,7 @@ import org.futo.inputmethod.latin.uix.PreferenceUtils
 import org.futo.inputmethod.latin.uix.SettingsKey
 import org.futo.inputmethod.latin.uix.USE_SYSTEM_VOICE_INPUT
 import org.futo.inputmethod.latin.uix.actions.fonttyper.FontTyperAction
+import org.futo.inputmethod.latin.uix.actions.SwitchAppsAction
 import org.futo.inputmethod.latin.uix.actions.AiReplyAction
 import org.futo.inputmethod.latin.uix.getSetting
 import org.futo.inputmethod.latin.uix.setSettingBlocking
@@ -41,6 +42,7 @@ val AllActionsMap = mapOf(
     "left" to ArrowLeftAction,
     "right" to ArrowRightAction,
     "font_typer" to FontTyperAction,
+    "switch_apps" to SwitchAppsAction,
     "ai_reply" to AiReplyAction
 )
 

--- a/java/src/org/futo/inputmethod/latin/uix/actions/SwitchAppsAction.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/SwitchAppsAction.kt
@@ -5,11 +5,15 @@ import org.futo.inputmethod.latin.R
 import org.futo.inputmethod.latin.uix.Action
 import org.futo.inputmethod.latin.uix.KeyboardManagerForAction
 import org.futo.inputmethod.latin.uix.services.QuickSwitchService
+import org.futo.inputmethod.latin.uix.ENABLE_SWITCH_APPS
+import org.futo.inputmethod.latin.uix.getSettingBlocking
 
 val SwitchAppsAction = Action(
     icon = R.drawable.move,
     name = R.string.action_switch_apps_title,
     simplePressImpl = { manager: KeyboardManagerForAction, _ ->
+        if(!manager.getContext().getSettingBlocking(ENABLE_SWITCH_APPS)) return@Action
+
         val service = QuickSwitchService.instance
         if (service != null) {
             service.switchToPreviousApp()

--- a/java/src/org/futo/inputmethod/latin/uix/actions/SwitchAppsAction.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/SwitchAppsAction.kt
@@ -1,0 +1,25 @@
+package org.futo.inputmethod.latin.uix.actions
+
+import android.widget.Toast
+import org.futo.inputmethod.latin.R
+import org.futo.inputmethod.latin.uix.Action
+import org.futo.inputmethod.latin.uix.KeyboardManagerForAction
+import org.futo.inputmethod.latin.uix.services.QuickSwitchService
+
+val SwitchAppsAction = Action(
+    icon = R.drawable.move,
+    name = R.string.action_switch_apps_title,
+    simplePressImpl = { manager: KeyboardManagerForAction, _ ->
+        val service = QuickSwitchService.instance
+        if (service != null) {
+            service.switchToPreviousApp()
+        } else {
+            Toast.makeText(
+                manager.getContext(),
+                manager.getContext().getString(R.string.action_switch_apps_enable_service),
+                Toast.LENGTH_SHORT
+            ).show()
+        }
+    },
+    windowImpl = null,
+)

--- a/java/src/org/futo/inputmethod/latin/uix/actions/VoiceInputAction.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/VoiceInputAction.kt
@@ -263,14 +263,14 @@ private class VoiceInputActionWindow(
     override fun finished(result: String) {
         wasFinished = true
 
-        val sanitized = ModelOutputSanitizer.sanitize(result, inputTransaction.textContext)
+        val sanitized = ModelOutputSanitizer.sanitize(result, inputTransaction.textContext, manager.isShifted())
         inputTransaction.commit(sanitized)
         manager.announce(result)
         manager.closeActionWindow()
     }
 
     override fun partialResult(result: String) {
-        val sanitized = ModelOutputSanitizer.sanitize(result, inputTransaction.textContext)
+        val sanitized = ModelOutputSanitizer.sanitize(result, inputTransaction.textContext, manager.isShifted())
         inputTransaction.updatePartial(sanitized)
     }
 

--- a/java/src/org/futo/inputmethod/latin/uix/services/QuickSwitchService.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/services/QuickSwitchService.kt
@@ -17,8 +17,8 @@ class QuickSwitchService : AccessibilityService() {
     }
 
     fun switchToPreviousApp() {
-        // GLOBAL_ACTION_TOGGLE_RECENTS should quickly switch to the last app
-        performGlobalAction(GLOBAL_ACTION_TOGGLE_RECENTS)
+        // Use recents action to toggle to the previous app
+        performGlobalAction(GLOBAL_ACTION_RECENTS)
     }
 
     companion object {

--- a/java/src/org/futo/inputmethod/latin/uix/services/QuickSwitchService.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/services/QuickSwitchService.kt
@@ -1,0 +1,27 @@
+package org.futo.inputmethod.latin.uix.services
+
+import android.accessibilityservice.AccessibilityService
+import android.view.accessibility.AccessibilityEvent
+
+class QuickSwitchService : AccessibilityService() {
+    override fun onAccessibilityEvent(event: AccessibilityEvent?) {}
+    override fun onInterrupt() {}
+
+    override fun onServiceConnected() {
+        instance = this
+    }
+
+    override fun onDestroy() {
+        instance = null
+        super.onDestroy()
+    }
+
+    fun switchToPreviousApp() {
+        // GLOBAL_ACTION_TOGGLE_RECENTS should quickly switch to the last app
+        performGlobalAction(GLOBAL_ACTION_TOGGLE_RECENTS)
+    }
+
+    companion object {
+        var instance: QuickSwitchService? = null
+    }
+}

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/AiReply.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/AiReply.kt
@@ -4,10 +4,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
 import org.futo.inputmethod.latin.R
 import org.futo.inputmethod.latin.uix.ENABLE_AI_REPLY
+import org.futo.inputmethod.latin.uix.AI_REPLY_PROMPT
 import org.futo.inputmethod.latin.uix.settings.NavigationItemStyle
 import org.futo.inputmethod.latin.uix.settings.UserSettingsMenu
 import org.futo.inputmethod.latin.uix.settings.userSettingNavigationItem
 import org.futo.inputmethod.latin.uix.settings.userSettingToggleDataStore
+import org.futo.inputmethod.latin.uix.settings.userSettingDecorationOnly
+import org.futo.inputmethod.latin.uix.settings.SettingTextField
 
 val AiReplyMenu = UserSettingsMenu(
     title = R.string.ai_reply_settings_title,
@@ -17,6 +20,13 @@ val AiReplyMenu = UserSettingsMenu(
             title = R.string.ai_reply_enable,
             setting = ENABLE_AI_REPLY
         ),
+        userSettingDecorationOnly {
+            SettingTextField(
+                title = stringResource(R.string.ai_reply_prompt_title),
+                placeholder = stringResource(R.string.ai_reply_prompt_placeholder),
+                field = AI_REPLY_PROMPT
+            )
+        },
         userSettingNavigationItem(
             title = R.string.ai_reply_groq_config,
             subtitle = R.string.ai_reply_groq_config_subtitle,

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/Misc.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/Misc.kt
@@ -9,6 +9,8 @@ import org.futo.inputmethod.latin.uix.settings.Tip
 import org.futo.inputmethod.latin.uix.settings.UserSettingsMenu
 import org.futo.inputmethod.latin.uix.settings.userSettingDecorationOnly
 import org.futo.inputmethod.latin.uix.settings.userSettingNavigationItem
+import org.futo.inputmethod.latin.uix.settings.userSettingToggleDataStore
+import org.futo.inputmethod.latin.uix.ENABLE_SWITCH_APPS
 
 val MiscMenu = UserSettingsMenu(
     title = R.string.misc_settings_title,
@@ -24,6 +26,10 @@ val MiscMenu = UserSettingsMenu(
             style = NavigationItemStyle.Misc,
             navigateTo = "exportingcfg"
         ).copy(searchTags = R.string.settings_import_export_tags),
+        userSettingToggleDataStore(
+            title = R.string.switch_apps_enable,
+            setting = ENABLE_SWITCH_APPS
+        ),
         userSettingNavigationItem(
             title = (R.string.settings_import_configuration),
             subtitle = (R.string.settings_import_configuration_subtitle),

--- a/java/src/org/futo/inputmethod/latin/uix/utils/ModelOutputSanitizer.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/utils/ModelOutputSanitizer.kt
@@ -32,12 +32,11 @@ object ModelOutputSanitizer {
     private val beforeEndsPunctRegex = Regex(".*[.:?!]$")
 
     @JvmStatic
-    fun sanitize(result: String, textContext: TextContext?): String {
-        if (textContext == null) {
-            return result
-        }
-
+    fun sanitize(result: String, textContext: TextContext?, isShifted: Boolean = false): String {
         val locale = RichInputMethodManager.getInstance().getCurrentSubtypeLocale()
+        if (textContext == null) {
+            return if(isShifted) result.uppercase(locale) else result
+        }
 
         var trimmed = result.trim()
         if (trimmed.isEmpty()) {
@@ -85,6 +84,11 @@ object ModelOutputSanitizer {
         val prefix = if (needsLeadingSpace) " " else ""
         val suffix = if (needsTrailingSpace) " " else ""
 
-        return prefix + trimmed + suffix
+        var finalText = trimmed
+        if(isShifted) {
+            finalText = finalText.uppercase(locale)
+        }
+
+        return prefix + finalText + suffix
     }
 }

--- a/tests/src/org/futo/inputmethod/latin/uix/utils/ModelOutputSanitizerTest.java
+++ b/tests/src/org/futo/inputmethod/latin/uix/utils/ModelOutputSanitizerTest.java
@@ -19,7 +19,7 @@ public class ModelOutputSanitizerTest {
     private final InputMethodSubtype mockSubtypeDe = Subtypes.INSTANCE.makeSubtype("de_DE", "qwertz");
 
     private static String sanitize(String input, TextContext context) {
-        return ModelOutputSanitizer.sanitize(input, context);
+        return ModelOutputSanitizer.sanitize(input, context, false);
     }
 
     private static class TestCase {
@@ -146,14 +146,20 @@ public class ModelOutputSanitizerTest {
     @Test
     public void testPreservesInternalSpacing() {
         TextContext context = new TextContext("Before", "after");
-        Assert.assertEquals(" hello   world ", ModelOutputSanitizer.sanitize("hello   world", context));
+        Assert.assertEquals(" hello   world ", ModelOutputSanitizer.sanitize("hello   world", context, false));
     }
 
     @Test
     public void testHandlesEllipsis() {
         Assert.assertEquals(
                 " hello world ",
-                ModelOutputSanitizer.sanitize("Hello world...", new TextContext("Before", "after"))
+                ModelOutputSanitizer.sanitize("Hello world...", new TextContext("Before", "after"), false)
         );
+    }
+
+    @Test
+    public void testCapsLockUppercases() {
+        TextContext context = new TextContext("", "");
+        Assert.assertEquals("HELLO", ModelOutputSanitizer.sanitize("hello", context, true));
     }
 }

--- a/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/groq/GroqModelPicker.kt
+++ b/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/groq/GroqModelPicker.kt
@@ -30,13 +30,19 @@ fun pickGroqModel(apiKey: String, preferredId: String = "llama3-70b-8192"): Stri
     }
 }
 
-fun stream(apiKey: String, prompt: String, preferredId: String? = null, onToken: (String) -> Unit) {
+fun stream(
+    apiKey: String,
+    systemPrompt: String,
+    userPrompt: String,
+    preferredId: String? = null,
+    onToken: (String) -> Unit
+) {
     val model = pickGroqModel(apiKey, preferredId ?: "llama3-70b-8192")
     val reqBody = """
       {
         "model":"$model",
         "stream":true,
-        "messages":[{"role":"user","content":"$prompt"}]
+        "messages":[{"role":"system","content":"$systemPrompt"},{"role":"user","content":"$userPrompt"}]
       }
     """.trimIndent()
 


### PR DESCRIPTION
## Summary
- allow customizing AI reply prompt with a new setting
- edit AI reply action to send clipboard text with the custom prompt
- expose prompt edit field in settings and action window
- update strings for prompt field
- update README feature list

## Testing
- `./gradlew --version`
- `./gradlew assembleUnstableDebug --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b5c44f16c8327af658498ebccdde3