### PR TITLE
Add fallback for T9 layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ If you forgot to specify recursive clone, use this to fetch submodules:
 ```
 git submodule update --init --recursive
 ```
+This pulls in the keyboard layouts submodule which includes the T9 phone layout
+and other custom layouts. Without it the keyboard falls back to the number
+layout when switching to T9, so updating the submodule is recommended.
 
 You can then open the project in Android Studio and build it that way, or use gradle commands:
 ```

--- a/java/src/org/futo/inputmethod/v2keyboard/KeyboardLayoutSet.kt
+++ b/java/src/org/futo/inputmethod/v2keyboard/KeyboardLayoutSet.kt
@@ -163,10 +163,15 @@ Layout: $it
 
     private val keyboardMode = getKeyboardMode(editorInfo)
 
-    private fun safeGetLayout(name: String): org.futo.inputmethod.v2keyboard.Keyboard =
+    private fun safeGetLayout(name: String, fallback: String? = null): org.futo.inputmethod.v2keyboard.Keyboard =
         try {
             LayoutManager.getLayout(context, name)
         } catch (e: Exception) {
+            fallback?.let {
+                try {
+                    return LayoutManager.getLayout(context, it)
+                } catch (_: Exception) {}
+            }
             BugViewerState.pushBug(BugInfo(
                 name = if(layoutName.startsWith("custom")) { "your custom layout" } else { "layout $layoutName" },
                 details =
@@ -189,8 +194,8 @@ Layout: $layoutName
     val symbolsLayout = safeGetLayout(mainLayout.layoutSetOverrides.symbols)
     val symbolsShiftedLayout = safeGetLayout(mainLayout.layoutSetOverrides.symbolsShifted)
     val numberLayout = safeGetLayout(mainLayout.layoutSetOverrides.number)
-    val phoneLayout = safeGetLayout(mainLayout.layoutSetOverrides.phone)
-    val phoneSymbolsLayout = safeGetLayout(mainLayout.layoutSetOverrides.phoneShifted)
+    val phoneLayout = safeGetLayout(mainLayout.layoutSetOverrides.phone, mainLayout.layoutSetOverrides.number)
+    val phoneSymbolsLayout = safeGetLayout(mainLayout.layoutSetOverrides.phoneShifted, mainLayout.layoutSetOverrides.number)
     val numberBasicLayout = safeGetLayout("number_basic")
 
     val elements = mapOf(


### PR DESCRIPTION
## Summary
- ensure phone layout falls back to number layout if missing
- explain fallback in README

## Testing
- `./gradlew test` *(fails to finish: NDK license not accepted)*

------
https://chatgpt.com/codex/tasks/task_e_686d1c2a15748327b89e78bb49cb50c4