### PR TITLE
Add persistent T9 mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Check out the [FUTO Keyboard website](https://keyboard.futo.org/) for downloads 
 - T9 phone layout accessible via the action key for quick number entry.
 - The T9 layout is also listed in the Keyboard Modes menu for easy access.
 - A new persistent T9 keyboard mode lets you keep the phone layout active until changed.
+- Long‑press spacebar drag now moves the cursor vertically when sliding up or down.
 
 The code is licensed under the [FUTO Source First License 1.1](LICENSE.md).
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Check out the [FUTO Keyboard website](https://keyboard.futo.org/) for downloads 
 - Quick Switch can be toggled in settings and uses an accessibility service to jump to your previously used app.
 - T9 phone layout accessible via the action key for quick number entry.
 - The T9 layout is also listed in the Keyboard Modes menu for easy access.
+- A new persistent T9 keyboard mode lets you keep the phone layout active until changed.
 
 The code is licensed under the [FUTO Source First License 1.1](LICENSE.md).
 

--- a/java/src/org/futo/inputmethod/keyboard/KeyboardActionListener.java
+++ b/java/src/org/futo/inputmethod/keyboard/KeyboardActionListener.java
@@ -102,6 +102,7 @@ public interface KeyboardActionListener {
     public boolean onCustomRequest(int requestCode);
 
     public void onMovePointer(int steps);
+    public void onMovePointerVertical(int steps);
     public void onMoveDeletePointer(int steps);
     public void onUpWithDeletePointerActive();
     public void onUpWithPointerActive();
@@ -135,6 +136,8 @@ public interface KeyboardActionListener {
         public boolean onCustomRequest(int requestCode) { return false; }
         @Override
         public void onMovePointer(int steps) {}
+        @Override
+        public void onMovePointerVertical(int steps) {}
         @Override
         public void onMoveDeletePointer(int steps) {}
         @Override

--- a/java/src/org/futo/inputmethod/keyboard/PointerTracker.java
+++ b/java/src/org/futo/inputmethod/keyboard/PointerTracker.java
@@ -935,6 +935,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
             }
 
             int steps = (x - mStartX) / pointerStep;
+            int vsteps = (y - mStartY) / pointerStep;
             final int swipeIgnoreTime = settingsValues.mKeyLongpressTimeout / MULTIPLIER_FOR_LONG_PRESS_TIMEOUT_IN_SLIDING_INPUT;
             if (steps != 0 && mStartTime + swipeIgnoreTime < System.currentTimeMillis()) {
                 mCursorMoved = true;
@@ -945,6 +946,12 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
                 } else {
                     sListener.onMovePointer(steps);
                 }
+            }
+
+            if (vsteps != 0 && mStartTime + swipeIgnoreTime < System.currentTimeMillis()) {
+                mCursorMoved = true;
+                mStartY += vsteps * pointerStep;
+                sListener.onMovePointerVertical(vsteps);
             }
 
             mLastX = x;

--- a/java/src/org/futo/inputmethod/latin/LatinIMELegacy.java
+++ b/java/src/org/futo/inputmethod/latin/LatinIMELegacy.java
@@ -1310,6 +1310,18 @@ public class LatinIMELegacy implements KeyboardActionListener,
     }
 
     @Override
+    public void onMovePointerVertical(int steps) {
+        setNeutralSuggestionStrip();
+
+        mInputLogic.mConnection.beginBatchEdit();
+        final int keyCode = steps < 0 ? KeyEvent.KEYCODE_DPAD_UP : KeyEvent.KEYCODE_DPAD_DOWN;
+        for(int i = 0; i < Math.abs(steps); i++) {
+            mInputLogic.sendDownUpKeyEvent(keyCode, 0);
+        }
+        mInputLogic.mConnection.endBatchEdit();
+    }
+
+    @Override
     public void onMoveDeletePointer(int steps) {
         setNeutralSuggestionStrip();
         if (mInputLogic.mConnection.hasCursorPosition()) {

--- a/java/src/org/futo/inputmethod/latin/inputlogic/InputLogic.java
+++ b/java/src/org/futo/inputmethod/latin/inputlogic/InputLogic.java
@@ -36,6 +36,7 @@ import org.futo.inputmethod.event.InputTransaction;
 import org.futo.inputmethod.keyboard.KeyDetector;
 import org.futo.inputmethod.keyboard.Keyboard;
 import org.futo.inputmethod.keyboard.KeyboardSwitcher;
+import org.futo.inputmethod.keyboard.internal.KeyboardLayoutKind;
 import org.futo.inputmethod.latin.Dictionary;
 import org.futo.inputmethod.latin.DictionaryFacilitator;
 import org.futo.inputmethod.latin.LastComposedWord;
@@ -110,6 +111,15 @@ public final class InputLogic {
     private boolean mIsAutoCorrectionIndicatorOn;
     private long mDoubleSpacePeriodCountdownStart;
 
+    // --- Persistent T9 phone layout support ---
+    private int mLastPhoneDigit = -1;
+    private int mLastPhoneTapIndex = 0;
+    private long mLastPhoneTapTime = 0;
+    private static final long PHONE_MULTI_TAP_DELAY = 800; // ms
+    private static final String[] PHONE_KEY_LETTERS = {
+            "", "", "ABC", "DEF", "GHI", "JKL", "MNO", "PQRS", "TUV", "WXYZ"
+    };
+
     // The word being corrected while the cursor is in the middle of the word.
     // Note: This does not have a composing span, so it must be handled separately.
     private String mWordBeingCorrectedByCursor = null;
@@ -120,6 +130,36 @@ public final class InputLogic {
     }
     public void endSuppressingLogic() {
         isLogicSuppressedByExternalLogic = false;
+    }
+
+    private boolean isPhoneLayout() {
+        final Keyboard keyboard = mLatinIMELegacy.mKeyboardSwitcher.getKeyboard();
+        if (keyboard == null) return false;
+        return keyboard.mId.mElement.getKind() == KeyboardLayoutKind.Phone;
+    }
+
+    private boolean handlePhoneMultiTap(final Event event, final InputTransaction inputTransaction,
+            final LatinIMELegacy.UIHandler handler) {
+        if (!isPhoneLayout() || event.isKeyRepeat()) return false;
+
+        final int codePoint = event.mCodePoint;
+        if (codePoint < '2' || codePoint > '9') return false;
+
+        final int digit = codePoint - '0';
+        final long now = inputTransaction.mTimestamp;
+        if (mLastPhoneDigit == digit && now - mLastPhoneTapTime < PHONE_MULTI_TAP_DELAY) {
+            mConnection.deleteTextBeforeCursor(1);
+            mLastPhoneTapIndex = (mLastPhoneTapIndex + 1) % PHONE_KEY_LETTERS[digit].length();
+        } else {
+            mLastPhoneDigit = digit;
+            mLastPhoneTapIndex = 0;
+        }
+        mLastPhoneTapTime = now;
+
+        final int letter = PHONE_KEY_LETTERS[digit].codePointAt(mLastPhoneTapIndex);
+        final Event letterEvent = Event.createSoftwareKeypressEvent(letter, letter, event.mX, event.mY, false);
+        handleNonFunctionalEvent(letterEvent, inputTransaction, handler);
+        return true;
     }
 
     /**
@@ -499,7 +539,7 @@ public final class InputLogic {
             } else if (currentEvent.isFunctionalKeyEvent()) {
                 handleFunctionalEvent(currentEvent, inputTransaction, currentKeyboardScriptId,
                         handler);
-            } else {
+            } else if (!handlePhoneMultiTap(currentEvent, inputTransaction, handler)) {
                 handleNonFunctionalEvent(currentEvent, inputTransaction, handler);
             }
             currentEvent = currentEvent.mNextEvent;

--- a/java/src/org/futo/inputmethod/latin/uix/actions/KeyboardSizingActions.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/KeyboardSizingActions.kt
@@ -33,9 +33,17 @@ import org.futo.inputmethod.v2keyboard.KeyboardMode
 import org.futo.inputmethod.v2keyboard.KeyboardSizingCalculator
 import org.futo.inputmethod.latin.uix.theme.Typography
 import org.futo.inputmethod.latin.common.Constants
+import org.futo.inputmethod.latin.uix.KeyboardManagerForAction
 
 @Composable
-private fun RowScope.KeyboardMode(iconRes: Int, checkedIconRes: Int, name: String, sizingCalculator: KeyboardSizingCalculator, mode: KeyboardMode) {
+private fun RowScope.KeyboardMode(
+    iconRes: Int,
+    checkedIconRes: Int,
+    name: String,
+    sizingCalculator: KeyboardSizingCalculator,
+    mode: KeyboardMode,
+    manager: KeyboardManagerForAction
+) {
     val isChecked = sizingCalculator.getSavedSettings().currentMode == mode
 
     Surface(
@@ -126,35 +134,35 @@ val KeyboardModeAction = Action(
                             R.drawable.keyboard_regular,
                             R.drawable.keyboard_fill_check,
                             stringResource(R.string.action_keyboard_modes_standard),
-                            sizeCalculator, KeyboardMode.Regular
+                            sizeCalculator, KeyboardMode.Regular, manager
                         )
 
                         KeyboardMode(
                             R.drawable.keyboard_left_handed,
                             R.drawable.keyboard_left_handed_fill_check,
                             stringResource(R.string.action_keyboard_modes_one_handed),
-                            sizeCalculator, KeyboardMode.OneHanded
+                            sizeCalculator, KeyboardMode.OneHanded, manager
                         )
 
                         KeyboardMode(
                             R.drawable.keyboard_split,
                             R.drawable.keyboard_split_fill_check,
                             stringResource(R.string.action_keyboard_modes_split),
-                            sizeCalculator, KeyboardMode.Split
+                            sizeCalculator, KeyboardMode.Split, manager
                         )
 
                         KeyboardMode(
                             R.drawable.keyboard_float,
                             R.drawable.keyboard_float_fill_check,
                             stringResource(R.string.action_keyboard_modes_floating),
-                            sizeCalculator, KeyboardMode.Floating
+                            sizeCalculator, KeyboardMode.Floating, manager
                         )
 
                         KeyboardMode(
                             R.drawable.numpad,
                             R.drawable.numpad,
                             stringResource(R.string.action_keyboard_modes_phone),
-                            sizeCalculator, KeyboardMode.Phone
+                            sizeCalculator, KeyboardMode.Phone, manager
                         )
                 }
             }
@@ -167,5 +175,4 @@ val KeyboardModeAction = Action(
                 return CloseResult.Default
             }
         }
-    },
-)
+    },)

--- a/java/src/org/futo/inputmethod/latin/uix/actions/KeyboardSizingActions.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/KeyboardSizingActions.kt
@@ -56,6 +56,9 @@ private fun RowScope.KeyboardMode(iconRes: Int, checkedIconRes: Int, name: Strin
                     }
                 }
             }
+            if(mode == KeyboardMode.Phone) {
+                manager.sendCodePointEvent(Constants.CODE_TO_PHONE_LAYOUT)
+            }
         },
         contentColor = if(isChecked) MaterialTheme.colorScheme.tertiary else MaterialTheme.colorScheme.onBackground
     ) {
@@ -140,31 +143,19 @@ val KeyboardModeAction = Action(
                             sizeCalculator, KeyboardMode.Split
                         )
 
-                    KeyboardMode(
-                        R.drawable.keyboard_float,
-                        R.drawable.keyboard_float_fill_check,
-                        stringResource(R.string.action_keyboard_modes_floating),
-                        sizeCalculator, KeyboardMode.Floating
-                    )
+                        KeyboardMode(
+                            R.drawable.keyboard_float,
+                            R.drawable.keyboard_float_fill_check,
+                            stringResource(R.string.action_keyboard_modes_floating),
+                            sizeCalculator, KeyboardMode.Floating
+                        )
 
-                    Surface(
-                        color = Color.Transparent,
-                        modifier = Modifier
-                            .weight(1.0f)
-                            .height(54.dp),
-                        onClick = {
-                            manager.sendCodePointEvent(Constants.CODE_TO_PHONE_LAYOUT)
-                            manager.closeActionWindow()
-                        },
-                        contentColor = MaterialTheme.colorScheme.onBackground
-                    ) {
-                        Box(Modifier.height(54.dp), contentAlignment = Alignment.Center) {
-                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                                Icon(painterResource(R.drawable.numpad), contentDescription = null)
-                                Text(stringResource(R.string.action_keyboard_modes_phone), style = Typography.SmallMl)
-                            }
-                        }
-                    }
+                        KeyboardMode(
+                            R.drawable.numpad,
+                            R.drawable.numpad,
+                            stringResource(R.string.action_keyboard_modes_phone),
+                            sizeCalculator, KeyboardMode.Phone
+                        )
                 }
             }
             }

--- a/java/src/org/futo/inputmethod/latin/uix/resizing/KeyboardResizers.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/resizing/KeyboardResizers.kt
@@ -48,7 +48,7 @@ open class KeyboardResizeHelper(
         var heightCorrection = 0.0f
         val bottomPadding = with(density) {
             var newBottomPadding = when (editedSettings.currentMode) {
-                KeyboardMode.Regular -> editedSettings.paddingDp.bottom
+                KeyboardMode.Regular, KeyboardMode.Phone -> editedSettings.paddingDp.bottom
                 KeyboardMode.Split -> editedSettings.splitPaddingDp.bottom
                 KeyboardMode.OneHanded -> editedSettings.oneHandedRectDp.bottom
                 KeyboardMode.Floating -> 0.dp
@@ -87,7 +87,7 @@ open class KeyboardResizeHelper(
         }
 
         editedSettings = when(editedSettings.currentMode) {
-            KeyboardMode.Regular -> editedSettings.copy(
+            KeyboardMode.Regular, KeyboardMode.Phone -> editedSettings.copy(
                 heightAdditionDp = editedSettings.heightAdditionDp + heightAdditionDiffDp.value,
                 paddingDp = editedSettings.paddingDp.copy(bottom = bottomPadding)
             )
@@ -106,7 +106,7 @@ open class KeyboardResizeHelper(
     fun applySymmetricalPaddingForRegular(sideDelta: Float) = with(density) {
         var newSidePadding =
             when (editedSettings.currentMode) {
-                KeyboardMode.Regular -> editedSettings.paddingDp.left
+                KeyboardMode.Regular, KeyboardMode.Phone -> editedSettings.paddingDp.left
                 KeyboardMode.Split -> editedSettings.splitPaddingDp.left
                 KeyboardMode.OneHanded -> editedSettings.oneHandedRectDp.left
                 KeyboardMode.Floating -> 0.dp
@@ -118,7 +118,7 @@ open class KeyboardResizeHelper(
         }
 
         editedSettings = when (editedSettings.currentMode) {
-            KeyboardMode.Regular -> editedSettings.copy(
+            KeyboardMode.Regular, KeyboardMode.Phone -> editedSettings.copy(
                 paddingDp = editedSettings.paddingDp.copy(
                     left = newSidePadding,
                     right = newSidePadding

--- a/java/src/org/futo/inputmethod/latin/uix/settings/Components.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/Components.kt
@@ -611,10 +611,10 @@ fun NavigationItem(title: String, style: NavigationItemStyle, navigate: () -> Un
                 val circleColor = when(style) {
                     NavigationItemStyle.HomePrimary,
                     NavigationItemStyle.HomeSecondary,
-                    NavigationItemStyle.HomeTertiary -> LocalKeyboardScheme.current.settingsIconBackground
-
+                    NavigationItemStyle.HomeTertiary,
                     NavigationItemStyle.MiscNoArrow,
-                    NavigationItemStyle.Misc,
+                    NavigationItemStyle.Misc -> LocalKeyboardScheme.current.settingsIconBackground
+
                     NavigationItemStyle.ExternalLink,
                     NavigationItemStyle.Mail -> Color.Transparent
                 }

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/Home.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/Home.kt
@@ -153,12 +153,14 @@ val HomeScreenLite = UserSettingsMenu(
             title = R.string.misc_settings_title,
             style = NavigationItemStyle.MiscNoArrow,
             navigateTo = "misc",
+            icon = R.drawable.settings
         ),
 
         userSettingNavigationItem(
             title = R.string.credits_menu_title,
             style = NavigationItemStyle.MiscNoArrow,
             navigateTo = "credits",
+            icon = R.drawable.book
         ),
     )
 )

--- a/java/src/org/futo/inputmethod/v2keyboard/KeyboardSizingCalculator.kt
+++ b/java/src/org/futo/inputmethod/v2keyboard/KeyboardSizingCalculator.kt
@@ -101,7 +101,8 @@ enum class KeyboardMode {
     Regular,
     Split,
     OneHanded,
-    Floating
+    Floating,
+    Phone
 }
 
 
@@ -350,6 +351,11 @@ class KeyboardSizingCalculator(val context: Context, val uixManager: UixManager)
                     heightAdditionDp = defaultSettings.heightAdditionDp,
                     paddingDp = defaultSettings.paddingDp
                 )
+                KeyboardMode.Phone -> it.copy(
+                    heightMultiplier = defaultSettings.heightMultiplier,
+                    heightAdditionDp = defaultSettings.heightAdditionDp,
+                    paddingDp = defaultSettings.paddingDp
+                )
                 KeyboardMode.Split -> it.copy(
                     splitPaddingDp = defaultSettings.splitPaddingDp,
                     splitHeightAdditionDp = defaultSettings.splitHeightAdditionDp,
@@ -387,6 +393,7 @@ class KeyboardSizingCalculator(val context: Context, val uixManager: UixManager)
 
         val heightAddition = when(savedSettings.currentMode) {
             KeyboardMode.Regular -> dp(savedSettings.heightAdditionDp)
+            KeyboardMode.Phone -> dp(savedSettings.heightAdditionDp)
             KeyboardMode.Split -> dp(savedSettings.splitHeightAdditionDp)
             KeyboardMode.OneHanded -> dp(savedSettings.oneHandedHeightAdditionDp)
             KeyboardMode.Floating -> 0
@@ -394,6 +401,7 @@ class KeyboardSizingCalculator(val context: Context, val uixManager: UixManager)
 
         val padding = when(savedSettings.currentMode) {
             KeyboardMode.Regular -> dp(savedSettings.paddingDp)
+            KeyboardMode.Phone -> dp(savedSettings.paddingDp)
             KeyboardMode.Split -> dp(savedSettings.splitPaddingDp)
             KeyboardMode.OneHanded -> dp(savedSettings.oneHandedRectDp).let { rect ->
                 when(savedSettings.oneHandedDirection) {
@@ -494,6 +502,14 @@ class KeyboardSizingCalculator(val context: Context, val uixManager: UixManager)
                     padding = padding
                 )
             }
+
+            savedSettings.currentMode == KeyboardMode.Phone ->
+                RegularKeyboardSize(
+                    width = width.coerceIn(dp(48), displayMetrics.widthPixels),
+                    height = recommendedHeight.roundToInt(),
+                    singleRowHeight = singularRowHeight.roundToInt(),
+                    padding = padding,
+                )
 
             else ->
                 RegularKeyboardSize(


### PR DESCRIPTION
## Summary
- add Phone to `KeyboardMode`
- support Phone mode in sizing calculator
- update keyboard modes action UI to toggle Phone mode
- document persistent T9 mode in README

## Testing
- `./gradlew test` *(fails: LicenceNotAcceptedException)*

------
https://chatgpt.com/codex/tasks/task_e_686d35d5d0f48327979c54aba09842ab