### PR TITLE
Fix icon and update workflow docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ To avoid Play Protect warnings when installing the APK, sign the release build w
 You can also provide these values in CI by setting the `KEYSTORE_*` secrets and
 running `setUpPropertiesCI.sh`.
 
-When running GitHub Actions workflows, use the latest `v4` releases of the standard actions such as `actions/upload-artifact@v4` to avoid deprecation errors.
+When running GitHub Actions workflows, use the latest `v4` releases of the standard actions such as `actions/upload-artifact@v4`. Using older versions like `v3` causes builds to fail with the error:
+```
+Error: This request has been automatically failed because it uses a deprecated version of actions/upload-artifact: v3.
+```
 
 An `update_with_backup.sh` script in the `tools` directory can install a new APK while exporting and restoring your existing preferences automatically.

--- a/build.gradle
+++ b/build.gradle
@@ -290,6 +290,7 @@ dependencies {
     implementation 'androidx.compose.animation:animation-core'
     implementation 'androidx.compose.ui:ui-tooling-preview'
     implementation 'androidx.compose.material3:material3'
+    implementation 'androidx.compose.material:material-icons-extended'
     implementation 'com.google.android.material:material:1.12.0'
     implementation 'androidx.appcompat:appcompat:1.7.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/ThemeGeneratorScreen.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/ThemeGeneratorScreen.kt
@@ -17,7 +17,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.FolderOpen
+import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
@@ -154,7 +154,7 @@ private fun ImagePicker(label: String, value: String, setValue: (String) -> Job)
         Text(label)
         Row(verticalAlignment = Alignment.CenterVertically) {
             IconButton(onClick = { launcher.launch(arrayOf("image/*")) }) {
-                Icon(Icons.Default.FolderOpen, contentDescription = null)
+                Icon(Icons.Filled.Folder, contentDescription = null)
             }
             if (value.isNotBlank()) Text(value)
         }


### PR DESCRIPTION
## Summary
- add missing material icons dependency
- use `Icons.Filled.Folder` instead of missing `FolderOpen`
- document deprecated `upload-artifact` error in README

## Testing
- `./gradlew tasks --all` *(fails: keystore and crashreporting properties missing)*

------
https://chatgpt.com/codex/tasks/task_e_686e4348e6688327b14db34d27340aa7