### PR TITLE
Add full theme color customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Check out the [FUTO Keyboard website](https://keyboard.futo.org/) for downloads 
 - AMOLED friendly dark themes with purple, red, blue, and green accents for battery savings.
 - Built-in theme generator lets you pick custom accent and base colors.
 - Theme generator now lets you pick accent, base, icon, and key colors with color pickers.
-- All colors from the default themes can be customized individually in the theme generator.
+- Every color from the default themes can be customized individually in the theme generator.
 - Background images can be loaded for custom themes.
 - Theme generator handles invalid color codes without crashing.
 - Settings icons use accent variations so each menu item has a unique color.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Check out the [FUTO Keyboard website](https://keyboard.futo.org/) for downloads 
 - AMOLED friendly dark themes with purple, red, blue, and green accents for battery savings.
 - Built-in theme generator lets you pick custom accent and base colors.
 - Theme generator now lets you pick accent, base, icon, and key colors with color pickers.
+- All colors from the default themes can be customized individually in the theme generator.
 - Background images can be loaded for custom themes.
 - Theme generator handles invalid color codes without crashing.
 - Settings icons use accent variations so each menu item has a unique color.

--- a/java/src/org/futo/inputmethod/latin/uix/Settings.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/Settings.kt
@@ -438,6 +438,135 @@ val CustomBackgroundImage = SettingsKey(
     default = ""
 )
 
+val CustomPrimaryColor = SettingsKey(
+    key = stringPreferencesKey("custom_primary_color"),
+    default = "#D0BCFF"
+)
+val CustomOnPrimaryColor = SettingsKey(
+    key = stringPreferencesKey("custom_on_primary_color"),
+    default = "#381E72"
+)
+val CustomPrimaryContainerColor = SettingsKey(
+    key = stringPreferencesKey("custom_primary_container_color"),
+    default = "#3A2966"
+)
+val CustomOnPrimaryContainerColor = SettingsKey(
+    key = stringPreferencesKey("custom_on_primary_container_color"),
+    default = "#E4D4FF"
+)
+val CustomSecondaryColor = SettingsKey(
+    key = stringPreferencesKey("custom_secondary_color"),
+    default = "#CFBAFF"
+)
+val CustomOnSecondaryColor = SettingsKey(
+    key = stringPreferencesKey("custom_on_secondary_color"),
+    default = "#3E2663"
+)
+val CustomSecondaryContainerColor = SettingsKey(
+    key = stringPreferencesKey("custom_secondary_container_color"),
+    default = "#1E192B"
+)
+val CustomOnSecondaryContainerColor = SettingsKey(
+    key = stringPreferencesKey("custom_on_secondary_container_color"),
+    default = "#AC9DC4"
+)
+val CustomTertiaryColor = SettingsKey(
+    key = stringPreferencesKey("custom_tertiary_color"),
+    default = "#F1FFA3"
+)
+val CustomOnTertiaryColor = SettingsKey(
+    key = stringPreferencesKey("custom_on_tertiary_color"),
+    default = "#444D12"
+)
+val CustomTertiaryContainerColor = SettingsKey(
+    key = stringPreferencesKey("custom_tertiary_container_color"),
+    default = "#5A6618"
+)
+val CustomOnTertiaryContainerColor = SettingsKey(
+    key = stringPreferencesKey("custom_on_tertiary_container_color"),
+    default = "#F9FFD6"
+)
+val CustomErrorColor = SettingsKey(
+    key = stringPreferencesKey("custom_error_color"),
+    default = "#FA7C75"
+)
+val CustomOnErrorColor = SettingsKey(
+    key = stringPreferencesKey("custom_on_error_color"),
+    default = "#591A16"
+)
+val CustomErrorContainerColor = SettingsKey(
+    key = stringPreferencesKey("custom_error_container_color"),
+    default = "#8C1D18"
+)
+val CustomOnErrorContainerColor = SettingsKey(
+    key = stringPreferencesKey("custom_on_error_container_color"),
+    default = "#F9AFA9"
+)
+val CustomOutlineColor = SettingsKey(
+    key = stringPreferencesKey("custom_outline_color"),
+    default = "#9E93AD"
+)
+val CustomOutlineVariantColor = SettingsKey(
+    key = stringPreferencesKey("custom_outline_variant_color"),
+    default = "#3B2D4F"
+)
+val CustomSurfaceColor = SettingsKey(
+    key = stringPreferencesKey("custom_surface_color"),
+    default = "#000000"
+)
+val CustomOnSurfaceColor = SettingsKey(
+    key = stringPreferencesKey("custom_on_surface_color"),
+    default = "#E6E1E5"
+)
+val CustomOnSurfaceVariantColor = SettingsKey(
+    key = stringPreferencesKey("custom_on_surface_variant_color"),
+    default = "#CCC1D6"
+)
+val CustomSurfaceContainerHighestColor = SettingsKey(
+    key = stringPreferencesKey("custom_surface_container_highest_color"),
+    default = "#232129"
+)
+val CustomShadowColor = SettingsKey(
+    key = stringPreferencesKey("custom_shadow_color"),
+    default = "#000000"
+)
+val CustomKeyboardSurfaceColor = SettingsKey(
+    key = stringPreferencesKey("custom_keyboard_surface_color"),
+    default = "#000000"
+)
+val CustomKeyboardContainerColor = SettingsKey(
+    key = stringPreferencesKey("custom_keyboard_container_color"),
+    default = "#1E192B"
+)
+val CustomKeyboardContainerVariantColor = SettingsKey(
+    key = stringPreferencesKey("custom_keyboard_container_variant_color"),
+    default = "#181324"
+)
+val CustomOnKeyboardContainerColor = SettingsKey(
+    key = stringPreferencesKey("custom_on_keyboard_container_color"),
+    default = "#E6E1E5"
+)
+val CustomKeyboardPressColor = SettingsKey(
+    key = stringPreferencesKey("custom_keyboard_press_color"),
+    default = "#31264F"
+)
+val CustomKeyboardFade0Color = SettingsKey(
+    key = stringPreferencesKey("custom_keyboard_fade0_color"),
+    default = "#000000"
+)
+val CustomKeyboardFade1Color = SettingsKey(
+    key = stringPreferencesKey("custom_keyboard_fade1_color"),
+    default = "#000000"
+)
+val CustomPrimaryTransparentColor = SettingsKey(
+    key = stringPreferencesKey("custom_primary_transparent_color"),
+    default = "#D0BCFF"
+)
+val CustomOnSurfaceTransparentColor = SettingsKey(
+    key = stringPreferencesKey("custom_on_surface_transparent_color"),
+    default = "#E6E1E5"
+)
+
 val USE_SYSTEM_VOICE_INPUT = SettingsKey(
     key = booleanPreferencesKey("useSystemVoiceInput"),
     default = false

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/ThemeGeneratorScreen.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/ThemeGeneratorScreen.kt
@@ -35,14 +35,44 @@ import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.Job
 import androidx.navigation.NavHostController
 import org.futo.inputmethod.latin.R
-import org.futo.inputmethod.latin.uix.CustomAccentColor
-import org.futo.inputmethod.latin.uix.CustomBaseColor
 import org.futo.inputmethod.latin.uix.CustomIconColor
 import org.futo.inputmethod.latin.uix.CustomIconBgColor
 import org.futo.inputmethod.latin.uix.CustomKeyBgColor
 import org.futo.inputmethod.latin.uix.CustomModifierColor
 import org.futo.inputmethod.latin.uix.CustomBorderColor
 import org.futo.inputmethod.latin.uix.CustomBackgroundImage
+import org.futo.inputmethod.latin.uix.CustomPrimaryColor
+import org.futo.inputmethod.latin.uix.CustomOnPrimaryColor
+import org.futo.inputmethod.latin.uix.CustomPrimaryContainerColor
+import org.futo.inputmethod.latin.uix.CustomOnPrimaryContainerColor
+import org.futo.inputmethod.latin.uix.CustomSecondaryColor
+import org.futo.inputmethod.latin.uix.CustomOnSecondaryColor
+import org.futo.inputmethod.latin.uix.CustomSecondaryContainerColor
+import org.futo.inputmethod.latin.uix.CustomOnSecondaryContainerColor
+import org.futo.inputmethod.latin.uix.CustomTertiaryColor
+import org.futo.inputmethod.latin.uix.CustomOnTertiaryColor
+import org.futo.inputmethod.latin.uix.CustomTertiaryContainerColor
+import org.futo.inputmethod.latin.uix.CustomOnTertiaryContainerColor
+import org.futo.inputmethod.latin.uix.CustomErrorColor
+import org.futo.inputmethod.latin.uix.CustomOnErrorColor
+import org.futo.inputmethod.latin.uix.CustomErrorContainerColor
+import org.futo.inputmethod.latin.uix.CustomOnErrorContainerColor
+import org.futo.inputmethod.latin.uix.CustomOutlineColor
+import org.futo.inputmethod.latin.uix.CustomOutlineVariantColor
+import org.futo.inputmethod.latin.uix.CustomSurfaceColor
+import org.futo.inputmethod.latin.uix.CustomOnSurfaceColor
+import org.futo.inputmethod.latin.uix.CustomOnSurfaceVariantColor
+import org.futo.inputmethod.latin.uix.CustomSurfaceContainerHighestColor
+import org.futo.inputmethod.latin.uix.CustomShadowColor
+import org.futo.inputmethod.latin.uix.CustomKeyboardSurfaceColor
+import org.futo.inputmethod.latin.uix.CustomKeyboardContainerColor
+import org.futo.inputmethod.latin.uix.CustomKeyboardContainerVariantColor
+import org.futo.inputmethod.latin.uix.CustomOnKeyboardContainerColor
+import org.futo.inputmethod.latin.uix.CustomKeyboardPressColor
+import org.futo.inputmethod.latin.uix.CustomKeyboardFade0Color
+import org.futo.inputmethod.latin.uix.CustomKeyboardFade1Color
+import org.futo.inputmethod.latin.uix.CustomPrimaryTransparentColor
+import org.futo.inputmethod.latin.uix.CustomOnSurfaceTransparentColor
 
 import org.futo.inputmethod.latin.uix.CustomHomePrimaryBgColor
 import org.futo.inputmethod.latin.uix.CustomHomeSecondaryBgColor
@@ -62,8 +92,40 @@ import org.futo.inputmethod.latin.uix.theme.presets.CustomTheme
 
 @Composable
 fun ThemeGeneratorScreen(navController: NavHostController) {
-    val (accent, setAccent) = useDataStore(CustomAccentColor)
-    val (base, setBase) = useDataStore(CustomBaseColor)
+    val colorSettings = listOf(
+        CustomPrimaryColor to "Primary",
+        CustomOnPrimaryColor to "On Primary",
+        CustomPrimaryContainerColor to "Primary Container",
+        CustomOnPrimaryContainerColor to "On Primary Container",
+        CustomSecondaryColor to "Secondary",
+        CustomOnSecondaryColor to "On Secondary",
+        CustomSecondaryContainerColor to "Secondary Container",
+        CustomOnSecondaryContainerColor to "On Secondary Container",
+        CustomTertiaryColor to "Tertiary",
+        CustomOnTertiaryColor to "On Tertiary",
+        CustomTertiaryContainerColor to "Tertiary Container",
+        CustomOnTertiaryContainerColor to "On Tertiary Container",
+        CustomErrorColor to "Error",
+        CustomOnErrorColor to "On Error",
+        CustomErrorContainerColor to "Error Container",
+        CustomOnErrorContainerColor to "On Error Container",
+        CustomOutlineColor to "Outline",
+        CustomOutlineVariantColor to "Outline Variant",
+        CustomSurfaceColor to "Surface",
+        CustomOnSurfaceColor to "On Surface",
+        CustomOnSurfaceVariantColor to "On Surface Variant",
+        CustomSurfaceContainerHighestColor to "Surface Container Highest",
+        CustomShadowColor to "Shadow",
+        CustomKeyboardSurfaceColor to "Keyboard Surface",
+        CustomKeyboardContainerColor to "Keyboard Container",
+        CustomKeyboardContainerVariantColor to "Keyboard Container Variant",
+        CustomOnKeyboardContainerColor to "On Keyboard Container",
+        CustomKeyboardPressColor to "Keyboard Press",
+        CustomKeyboardFade0Color to "Keyboard Fade0",
+        CustomKeyboardFade1Color to "Keyboard Fade1",
+        CustomPrimaryTransparentColor to "Primary Transparent",
+        CustomOnSurfaceTransparentColor to "On Surface Transparent"
+    )
     val (icon, setIcon) = useDataStore(CustomIconColor)
     val (iconBg, setIconBg) = useDataStore(CustomIconBgColor)
     val (keyBg, setKeyBg) = useDataStore(CustomKeyBgColor)
@@ -88,8 +150,10 @@ fun ThemeGeneratorScreen(navController: NavHostController) {
             .verticalScroll(scrollState)
     ) {
         ScreenTitle(stringResource(R.string.theme_generator_title), showBack = true, navController)
-        ColorPicker(stringResource(R.string.theme_generator_accent), accent, setAccent)
-        ColorPicker(stringResource(R.string.theme_generator_base), base, setBase)
+        colorSettings.forEach { (key, label) ->
+            val (value, setter) = useDataStore(key)
+            ColorPicker(label, value, setter)
+        }
         ColorPicker(stringResource(R.string.theme_generator_icon), icon, setIcon)
         ColorPicker("Icon Background", iconBg, setIconBg)
         ColorPicker("Key Background", keyBg, setKeyBg)

--- a/java/src/org/futo/inputmethod/latin/uix/theme/presets/CustomTheme.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/theme/presets/CustomTheme.kt
@@ -4,14 +4,44 @@ import android.graphics.Color.parseColor
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
 import org.futo.inputmethod.latin.R
-import org.futo.inputmethod.latin.uix.CustomAccentColor
-import org.futo.inputmethod.latin.uix.CustomBaseColor
 import org.futo.inputmethod.latin.uix.CustomIconColor
 import org.futo.inputmethod.latin.uix.CustomIconBgColor
 import org.futo.inputmethod.latin.uix.CustomKeyBgColor
 import org.futo.inputmethod.latin.uix.CustomModifierColor
 import org.futo.inputmethod.latin.uix.CustomBorderColor
 import org.futo.inputmethod.latin.uix.CustomBackgroundImage
+import org.futo.inputmethod.latin.uix.CustomPrimaryColor
+import org.futo.inputmethod.latin.uix.CustomOnPrimaryColor
+import org.futo.inputmethod.latin.uix.CustomPrimaryContainerColor
+import org.futo.inputmethod.latin.uix.CustomOnPrimaryContainerColor
+import org.futo.inputmethod.latin.uix.CustomSecondaryColor
+import org.futo.inputmethod.latin.uix.CustomOnSecondaryColor
+import org.futo.inputmethod.latin.uix.CustomSecondaryContainerColor
+import org.futo.inputmethod.latin.uix.CustomOnSecondaryContainerColor
+import org.futo.inputmethod.latin.uix.CustomTertiaryColor
+import org.futo.inputmethod.latin.uix.CustomOnTertiaryColor
+import org.futo.inputmethod.latin.uix.CustomTertiaryContainerColor
+import org.futo.inputmethod.latin.uix.CustomOnTertiaryContainerColor
+import org.futo.inputmethod.latin.uix.CustomErrorColor
+import org.futo.inputmethod.latin.uix.CustomOnErrorColor
+import org.futo.inputmethod.latin.uix.CustomErrorContainerColor
+import org.futo.inputmethod.latin.uix.CustomOnErrorContainerColor
+import org.futo.inputmethod.latin.uix.CustomOutlineColor
+import org.futo.inputmethod.latin.uix.CustomOutlineVariantColor
+import org.futo.inputmethod.latin.uix.CustomSurfaceColor
+import org.futo.inputmethod.latin.uix.CustomOnSurfaceColor
+import org.futo.inputmethod.latin.uix.CustomOnSurfaceVariantColor
+import org.futo.inputmethod.latin.uix.CustomSurfaceContainerHighestColor
+import org.futo.inputmethod.latin.uix.CustomShadowColor
+import org.futo.inputmethod.latin.uix.CustomKeyboardSurfaceColor
+import org.futo.inputmethod.latin.uix.CustomKeyboardContainerColor
+import org.futo.inputmethod.latin.uix.CustomKeyboardContainerVariantColor
+import org.futo.inputmethod.latin.uix.CustomOnKeyboardContainerColor
+import org.futo.inputmethod.latin.uix.CustomKeyboardPressColor
+import org.futo.inputmethod.latin.uix.CustomKeyboardFade0Color
+import org.futo.inputmethod.latin.uix.CustomKeyboardFade1Color
+import org.futo.inputmethod.latin.uix.CustomPrimaryTransparentColor
+import org.futo.inputmethod.latin.uix.CustomOnSurfaceTransparentColor
 import org.futo.inputmethod.latin.uix.getSetting
 import org.futo.inputmethod.latin.uix.extendedDarkColorScheme
 import org.futo.inputmethod.latin.uix.theme.ThemeOption
@@ -20,64 +50,6 @@ private fun safeColor(code: String, fallback: String): Color {
     return try { Color(parseColor(code)) } catch (_: IllegalArgumentException) { Color(parseColor(fallback)) }
 }
 
-private fun lighten(color: Color, amount: Float): Color {
-    return Color(
-        red = color.red + (1f - color.red) * amount,
-        green = color.green + (1f - color.green) * amount,
-        blue = color.blue + (1f - color.blue) * amount,
-        alpha = color.alpha
-    )
-}
-
-private fun idealOnColor(color: Color): Color {
-    return if (color.luminance() > 0.5f) Color.Black else Color.White
-}
-
-private fun colorsFrom(
-    accent: Color,
-    base: Color,
-    icon: Color,
-    iconBg: Color,
-    keyBg: Color,
-    modifierBg: Color,
-    border: Color,
-    backgroundImage: String,
-) = extendedDarkColorScheme(
-    primary = accent,
-    onPrimary = idealOnColor(accent),
-    primaryContainer = accent,
-    onPrimaryContainer = idealOnColor(accent),
-    secondary = lighten(accent, 0.2f),
-    onSecondary = idealOnColor(lighten(accent, 0.2f)),
-    secondaryContainer = lighten(accent, 0.2f),
-    onSecondaryContainer = idealOnColor(lighten(accent, 0.2f)),
-    tertiary = lighten(accent, 0.4f),
-    onTertiary = idealOnColor(lighten(accent, 0.4f)),
-    tertiaryContainer = lighten(accent, 0.4f),
-    onTertiaryContainer = idealOnColor(lighten(accent, 0.4f)),
-    error = Color(0xFFFA6060),
-    onError = Color.Black,
-    errorContainer = Color(0xFF730000),
-    onErrorContainer = Color.White,
-    outline = border,
-    outlineVariant = border.copy(alpha = 0.4f),
-    surface = base,
-    onSurface = Color.White,
-    onSurfaceVariant = Color.White,
-    surfaceContainerHighest = base,
-    keyboardSurface = base,
-    keyboardContainer = keyBg,
-    keyboardContainerVariant = modifierBg,
-    onKeyboardContainer = idealOnColor(keyBg),
-    keyboardPress = accent.copy(alpha = 0.7f),
-    keyboardFade0 = base,
-    keyboardFade1 = base,
-    keyboardBackgroundShader = if (backgroundImage.isNotEmpty()) backgroundImage else null,
-    primaryTransparent = accent.copy(alpha = 0.3f),
-    onSurfaceTransparent = Color.White.copy(alpha = 0.1f),
-    settingsIconColor = icon,
-    keyboardSurfaceDim = base,
-)
 
 val CustomTheme = ThemeOption(
     dynamic = false,

--- a/java/src/org/futo/inputmethod/latin/uix/theme/presets/CustomTheme.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/theme/presets/CustomTheme.kt
@@ -85,21 +85,53 @@ val CustomTheme = ThemeOption(
     name = R.string.theme_custom,
     available = { true },
     obtainColors = {
-        val accentStr = it.getSetting(CustomAccentColor)
-        val baseStr = it.getSetting(CustomBaseColor)
-        val accent = safeColor(accentStr, CustomAccentColor.default)
-        val base = safeColor(baseStr, CustomBaseColor.default)
-        val iconStr = it.getSetting(CustomIconColor)
-        val icon = safeColor(iconStr, CustomIconColor.default)
-        val iconBgStr = it.getSetting(CustomIconBgColor)
-        val iconBg = safeColor(iconBgStr, CustomIconBgColor.default)
-        val keyBgStr = it.getSetting(CustomKeyBgColor)
-        val keyBg = safeColor(keyBgStr, CustomKeyBgColor.default)
-        val modBgStr = it.getSetting(CustomModifierColor)
-        val modBg = safeColor(modBgStr, CustomModifierColor.default)
-        val borderStr = it.getSetting(CustomBorderColor)
-        val border = safeColor(borderStr, CustomBorderColor.default)
+        val icon = safeColor(it.getSetting(CustomIconColor), CustomIconColor.default)
+        val iconBg = safeColor(it.getSetting(CustomIconBgColor), CustomIconBgColor.default)
+        val keyBg = safeColor(it.getSetting(CustomKeyBgColor), CustomKeyBgColor.default)
+        val modBg = safeColor(it.getSetting(CustomModifierColor), CustomModifierColor.default)
+        val border = safeColor(it.getSetting(CustomBorderColor), CustomBorderColor.default)
         val bgImage = it.getSetting(CustomBackgroundImage)
-        colorsFrom(accent, base, icon, iconBg, keyBg, modBg, border, bgImage)
+
+        extendedDarkColorScheme(
+            primary = safeColor(it.getSetting(CustomPrimaryColor), CustomPrimaryColor.default),
+            onPrimary = safeColor(it.getSetting(CustomOnPrimaryColor), CustomOnPrimaryColor.default),
+            primaryContainer = safeColor(it.getSetting(CustomPrimaryContainerColor), CustomPrimaryContainerColor.default),
+            onPrimaryContainer = safeColor(it.getSetting(CustomOnPrimaryContainerColor), CustomOnPrimaryContainerColor.default),
+            secondary = safeColor(it.getSetting(CustomSecondaryColor), CustomSecondaryColor.default),
+            onSecondary = safeColor(it.getSetting(CustomOnSecondaryColor), CustomOnSecondaryColor.default),
+            secondaryContainer = safeColor(it.getSetting(CustomSecondaryContainerColor), CustomSecondaryContainerColor.default),
+            onSecondaryContainer = safeColor(it.getSetting(CustomOnSecondaryContainerColor), CustomOnSecondaryContainerColor.default),
+            tertiary = safeColor(it.getSetting(CustomTertiaryColor), CustomTertiaryColor.default),
+            onTertiary = safeColor(it.getSetting(CustomOnTertiaryColor), CustomOnTertiaryColor.default),
+            tertiaryContainer = safeColor(it.getSetting(CustomTertiaryContainerColor), CustomTertiaryContainerColor.default),
+            onTertiaryContainer = safeColor(it.getSetting(CustomOnTertiaryContainerColor), CustomOnTertiaryContainerColor.default),
+            error = safeColor(it.getSetting(CustomErrorColor), CustomErrorColor.default),
+            onError = safeColor(it.getSetting(CustomOnErrorColor), CustomOnErrorColor.default),
+            errorContainer = safeColor(it.getSetting(CustomErrorContainerColor), CustomErrorContainerColor.default),
+            onErrorContainer = safeColor(it.getSetting(CustomOnErrorContainerColor), CustomOnErrorContainerColor.default),
+            outline = safeColor(it.getSetting(CustomOutlineColor), CustomOutlineColor.default),
+            outlineVariant = safeColor(it.getSetting(CustomOutlineVariantColor), CustomOutlineVariantColor.default),
+            surface = safeColor(it.getSetting(CustomSurfaceColor), CustomSurfaceColor.default),
+            onSurface = safeColor(it.getSetting(CustomOnSurfaceColor), CustomOnSurfaceColor.default),
+            onSurfaceVariant = safeColor(it.getSetting(CustomOnSurfaceVariantColor), CustomOnSurfaceVariantColor.default),
+            surfaceContainerHighest = safeColor(it.getSetting(CustomSurfaceContainerHighestColor), CustomSurfaceContainerHighestColor.default),
+            shadow = safeColor(it.getSetting(CustomShadowColor), CustomShadowColor.default),
+            keyboardSurface = safeColor(it.getSetting(CustomKeyboardSurfaceColor), CustomKeyboardSurfaceColor.default),
+            keyboardContainer = safeColor(it.getSetting(CustomKeyboardContainerColor), CustomKeyboardContainerColor.default),
+            keyboardContainerVariant = safeColor(it.getSetting(CustomKeyboardContainerVariantColor), CustomKeyboardContainerVariantColor.default),
+            onKeyboardContainer = safeColor(it.getSetting(CustomOnKeyboardContainerColor), CustomOnKeyboardContainerColor.default),
+            keyboardPress = safeColor(it.getSetting(CustomKeyboardPressColor), CustomKeyboardPressColor.default),
+            keyboardFade0 = safeColor(it.getSetting(CustomKeyboardFade0Color), CustomKeyboardFade0Color.default),
+            keyboardFade1 = safeColor(it.getSetting(CustomKeyboardFade1Color), CustomKeyboardFade1Color.default),
+            keyboardBackgroundGradient = null,
+            primaryTransparent = safeColor(it.getSetting(CustomPrimaryTransparentColor), CustomPrimaryTransparentColor.default),
+            onSurfaceTransparent = safeColor(it.getSetting(CustomOnSurfaceTransparentColor), CustomOnSurfaceTransparentColor.default),
+            settingsIconColor = icon,
+            settingsIconBackground = iconBg,
+            keyboardSurfaceDim = safeColor(it.getSetting(CustomSurfaceColor), CustomSurfaceColor.default),
+            keyboardContainerPressed = border.copy(alpha = 0.33f),
+            onKeyboardContainerPressed = Color.Transparent,
+            keyboardBackgroundShader = if (bgImage.isNotEmpty()) bgImage else null,
+        )
     }
 )


### PR DESCRIPTION
## Summary
- expose every default theme color as customizable setting
- loop through all color settings in the theme generator UI
- build custom theme from individual color selections
- document full color customization feature

## Testing
- `./gradlew assembleUnstableDebug` *(fails: LicenceNotAcceptedException)*

------
https://chatgpt.com/codex/tasks/task_e_686e62ea389c8327af95d838f8a3cfde