### PR TITLE
Reset clipboard search when closing window

### DIFF
--- a/java/src/org/futo/inputmethod/latin/uix/UixManager.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/UixManager.kt
@@ -713,6 +713,13 @@ class UixManager(private val latinIME: LatinIME) {
         latinIME.window.window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
 
         keyboardManagerForAction.announce(latinIME.getString(R.string.action_menu_closed, name))
+
+        // Ensure clipboard search mode is fully reset when leaving an action
+        if(isClipboardSearchFocused.value) {
+            isClipboardSearchFocused.value = false
+            clipboardSearchQuery.value = ""
+            requestSearchFocus.value = false
+        }
         return true
     }
 


### PR DESCRIPTION
## Summary
- ensure clipboard search focus resets when closing any action window

## Testing
- `./gradlew assembleRelease` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871273adb048327acc4e0b80b34f447