### PR TITLE
Fix stuck backspace after closing clipboard search

### DIFF
--- a/java/src/org/futo/inputmethod/latin/uix/UixManager.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/UixManager.kt
@@ -706,6 +706,9 @@ class UixManager(private val latinIME: LatinIME) {
         currWindowAction.value = null
         currWindowActionWindow.value = null
 
+        // Ensure clipboard search state is reset when leaving the action
+        keyboardManagerForAction.setClipboardSearchFocus(false)
+
         mainKeyboardHidden.value = false
 
         latinIME.onKeyboardShown()


### PR DESCRIPTION
## Summary
- reset clipboard search focus when exiting action window

## Testing
- `./gradlew assembleRelease` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871273adb048327acc4e0b80b34f447