### PR TITLE
Fix backspace when leaving clipboard search

### DIFF
--- a/java/src/org/futo/inputmethod/latin/uix/UixManager.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/UixManager.kt
@@ -703,6 +703,12 @@ class UixManager(private val latinIME: LatinIME) {
             return false
         }
 
+        // If we are closing the clipboard history window, ensure the clipboard
+        // search state is reset so normal keyboard input works again.
+        if (currWindowAction.value == ClipboardHistoryAction) {
+            keyboardManagerForAction.setClipboardSearchFocus(false)
+        }
+
         currWindowAction.value = null
         currWindowActionWindow.value = null
 


### PR DESCRIPTION
## Summary
- reset clipboard search focus when leaving clipboard history window

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871273adb048327acc4e0b80b34f447