### PR TITLE
Handle back press in clipboard history

### DIFF
--- a/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryComposables.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryComposables.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.activity.compose.BackHandler
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -309,6 +310,10 @@ fun ClipboardHistoryWindowContent(
                 }
             }
         }
+    }
+
+    BackHandler {
+        manager.closeActionWindow()
     }
 
     Column(modifier = Modifier.fillMaxWidth()) {


### PR DESCRIPTION
## Summary
- collapse clipboard history when the system back button is pressed

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871636fe9448327a907d85ae9fe0477