### PR TITLE
Handle back button in clipboard history

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Check out the [FUTO Keyboard website](https://keyboard.futo.org/) for downloads 
 - A file picker lets you choose a background image for the keyboard layout.
 - Each settings icon background color is adjustable from the theme generator.
 - Copying text shows an "AI Generate" option in the suggestion strip
+- Pressing Android's back button while clipboard history is open now collapses it and returns focus to your input field
 
 - Long‑press spacebar drag now moves the cursor vertically when sliding up or down.
 

--- a/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryComposables.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryComposables.kt
@@ -1,5 +1,6 @@
 package org.futo.inputmethod.latin.uix.actions
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
@@ -261,6 +262,9 @@ fun ClipboardHistoryWindowContent(
 ) {
     val view = LocalView.current
     val context = LocalContext.current
+    BackHandler {
+        manager.closeActionWindow()
+    }
     val clipboardHistoryEnabledState = useDataStore(ClipboardHistoryEnabled, blocking = true)
     val focusRequester = remember { FocusRequester() }
     // val localFocusManager = LocalFocusManager.current // Not strictly needed if we change focus logic


### PR DESCRIPTION
## Summary
- collapse clipboard history on Android back button
- document new behavior in README

## Testing
- `./gradlew assembleRelease` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871636fe9448327a907d85ae9fe0477