### PR TITLE
Add BackHandler for clipboard history

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Check out the [FUTO Keyboard website](https://keyboard.futo.org/) for downloads 
 - A file picker lets you choose a background image for the keyboard layout.
 - Each settings icon background color is adjustable from the theme generator.
 - Copying text shows an "AI Generate" option in the suggestion strip
+- Pressing the Android back button collapses the clipboard history window and returns focus to your input field
 
 - Long‑press spacebar drag now moves the cursor vertically when sliding up or down.
 

--- a/java/src/org/futo/inputmethod/latin/uix/UixManager.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/UixManager.kt
@@ -87,6 +87,7 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.coerceAtLeast
 import androidx.compose.ui.unit.dp
+import androidx.activity.compose.BackHandler
 import androidx.core.view.inputmethod.InputConnectionCompat
 import androidx.core.view.inputmethod.InputContentInfoCompat
 import androidx.lifecycle.LifecycleCoroutineScope
@@ -1202,6 +1203,10 @@ class UixManager(private val latinIME: LatinIME) {
     @Composable
     fun Content() {
         ProvidersAndWrapper {
+            BackHandler(currWindowActionWindow.value != null) {
+                closeActionWindow()
+            }
+
             InputDarkener(isInputOverridden.value || isShowingActionEditor.value) {
                 closeActionWindow()
                 isShowingActionEditor.value = false


### PR DESCRIPTION
## Summary
- collapse clipboard history with Back button
- document clipboard collapse in README

## Testing
- `./gradlew assembleRelease` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871636fe9448327a907d85ae9fe0477