### PR TITLE
Handle back key in clipboard history

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Check out the [FUTO Keyboard website](https://keyboard.futo.org/) for downloads 
 - Groq Reply API settings store a separate API key and model for chat completions.
 - AI Reply prompt can be customized from the keyboard or settings and the clipboard text is sent to Groq for context.
 - AI Reply now always uses the most recent clipboard entry when generating a reply, even when launched directly from the actions row.
+- Pressing the back button while viewing clipboard history now collapses it and
+  returns focus to your original input field.
 - Voice recognition output is normalized so repeated words are removed.
 - Voice input respects the keyboard's caps lock state.
 - Long voice recordings are transcribed in 30 second chunks so earlier audio isn't overwritten.

--- a/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryComposables.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryComposables.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalView
+import androidx.activity.compose.BackHandler
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -259,6 +260,9 @@ fun ClipboardHistoryWindowContent(
     unlocked: Boolean,
     keyboardShown: Boolean
 ) {
+    BackHandler(enabled = true) {
+        manager.closeActionWindow()
+    }
     val view = LocalView.current
     val context = LocalContext.current
     val clipboardHistoryEnabledState = useDataStore(ClipboardHistoryEnabled, blocking = true)


### PR DESCRIPTION
## Summary
- collapse clipboard history when the Android back button is pressed
- document the new back button behaviour in the feature list

## Testing
- `./gradlew assembleRelease` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871636fe9448327a907d85ae9fe0477