### PR TITLE
Handle back key for clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Check out the [FUTO Keyboard website](https://keyboard.futo.org/) for downloads 
 - New settings search button at the bottom of the settings screen highlights itself with a smooth repeating border animation for easier discovery.
 - AI Reply menu for configuring Groq-powered quick replies.
 - AI reply generation now streams responses using coroutines for smoother updates.
-- Quick Switch can be toggled in settings and opens your last used app using usage access. It now skips system apps so you return to the real previous app.
+- Quick Switch can be toggled in settings and opens your last used app by analyzing usage stats.
 - T9 phone layout accessible via the action key for quick number entry.
 - The T9 layout is also listed in the Keyboard Modes menu for easy access.
 - A new persistent T9 keyboard mode lets you keep the phone layout active until changed.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Check out the [FUTO Keyboard website](https://keyboard.futo.org/) for downloads 
 - New settings search button at the bottom of the settings screen highlights itself with a smooth repeating border animation for easier discovery.
 - AI Reply menu for configuring Groq-powered quick replies.
 - AI reply generation now streams responses using coroutines for smoother updates.
-- Quick Switch can be toggled in settings and uses an accessibility service to jump to your previously used app.
+- Quick Switch can be toggled in settings and opens your last app directly using usage access (falls back to recents if permission isn't granted).
 - T9 phone layout accessible via the action key for quick number entry.
 - The T9 layout is also listed in the Keyboard Modes menu for easy access.
 - A new persistent T9 keyboard mode lets you keep the phone layout active until changed.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Check out the [FUTO Keyboard website](https://keyboard.futo.org/) for downloads 
 - New settings search button at the bottom of the settings screen highlights itself with a smooth repeating border animation for easier discovery.
 - AI Reply menu for configuring Groq-powered quick replies.
 - AI reply generation now streams responses using coroutines for smoother updates.
-- Quick Switch can be toggled in settings and opens your last app directly using usage access (falls back to recents if permission isn't granted).
+- Quick Switch can be toggled in settings and opens your last used app using usage access. It now skips system apps so you return to the real previous app.
 - T9 phone layout accessible via the action key for quick number entry.
 - The T9 layout is also listed in the Keyboard Modes menu for easy access.
 - A new persistent T9 keyboard mode lets you keep the phone layout active until changed.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Check out the [FUTO Keyboard website](https://keyboard.futo.org/) for downloads 
 - Groq Reply API settings store a separate API key and model for chat completions.
 - AI Reply prompt can be customized from the keyboard or settings and the clipboard text is sent to Groq for context.
 - AI Reply now always uses the most recent clipboard entry when generating a reply, even when launched directly from the actions row.
+- Clipboard history collapses with the Android back key so the keyboard stays open.
 - Voice recognition output is normalized so repeated words are removed.
 - Voice input respects the keyboard's caps lock state.
 - Long voice recordings are transcribed in 30 second chunks so earlier audio isn't overwritten.

--- a/java/AndroidManifest.xml
+++ b/java/AndroidManifest.xml
@@ -27,6 +27,7 @@
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE"/>
+    <uses-permission android:name="android.permission.PACKAGE_USAGE_STATS" tools:ignore="ProtectedPermissions"/>
 
     <application android:label="@string/english_ime_name"
          android:icon="@mipmap/ic_launcher"

--- a/java/src/org/futo/inputmethod/latin/LatinIME.kt
+++ b/java/src/org/futo/inputmethod/latin/LatinIME.kt
@@ -783,6 +783,10 @@ class LatinIME : InputMethodServiceCompose(), LatinIMELegacy.SuggestionStripCont
     }
 
     override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
+        if(keyCode == KeyEvent.KEYCODE_BACK && uixManager.currWindowAction.value != null) {
+            uixManager.closeActionWindow()
+            return true
+        }
         return latinIMELegacy.onKeyDown(keyCode, event) || super.onKeyDown(keyCode, event)
     }
 

--- a/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryComposables.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryComposables.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
+import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -264,6 +265,10 @@ fun ClipboardHistoryWindowContent(
     val clipboardHistoryEnabledState = useDataStore(ClipboardHistoryEnabled, blocking = true)
     val focusRequester = remember { FocusRequester() }
     // val localFocusManager = LocalFocusManager.current // Not strictly needed if we change focus logic
+
+    BackHandler {
+        manager.closeActionWindow()
+    }
 
 
     // Use TextFieldValue to manage cursor position

--- a/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryComposables.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryComposables.kt
@@ -37,7 +37,6 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.activity.compose.BackHandler
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -266,9 +265,6 @@ fun ClipboardHistoryWindowContent(
     val focusRequester = remember { FocusRequester() }
     // val localFocusManager = LocalFocusManager.current // Not strictly needed if we change focus logic
 
-    BackHandler {
-        manager.closeActionWindow()
-    }
 
     // Use TextFieldValue to manage cursor position
     var textFieldValue by remember {

--- a/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryComposables.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryComposables.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.activity.compose.BackHandler
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -265,9 +266,13 @@ fun ClipboardHistoryWindowContent(
     val focusRequester = remember { FocusRequester() }
     // val localFocusManager = LocalFocusManager.current // Not strictly needed if we change focus logic
 
+    BackHandler {
+        manager.closeActionWindow()
+    }
+
     // Use TextFieldValue to manage cursor position
-    var textFieldValue by remember { 
-        mutableStateOf(TextFieldValue(manager.getClipboardSearchQuery())) 
+    var textFieldValue by remember {
+        mutableStateOf(TextFieldValue(manager.getClipboardSearchQuery()))
     }
     
     // Track if we're currently updating from the manager to prevent loops

--- a/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryComposables.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryComposables.kt
@@ -311,6 +311,7 @@ fun ClipboardHistoryWindowContent(
         }
     }
 
+
     Column(modifier = Modifier.fillMaxWidth()) {
         // Use TextField with TextFieldValue for better cursor control
         TextField(

--- a/java/src/org/futo/inputmethod/latin/uix/actions/SwitchAppsAction.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/SwitchAppsAction.kt
@@ -1,6 +1,10 @@
 package org.futo.inputmethod.latin.uix.actions
 
 import android.widget.Toast
+import android.app.AppOpsManager
+import android.content.Context
+import android.provider.Settings
+import android.content.Intent
 import org.futo.inputmethod.latin.R
 import org.futo.inputmethod.latin.uix.Action
 import org.futo.inputmethod.latin.uix.KeyboardManagerForAction
@@ -14,13 +18,25 @@ val SwitchAppsAction = Action(
     simplePressImpl = { manager: KeyboardManagerForAction, _ ->
         if(!manager.getContext().getSettingBlocking(ENABLE_SWITCH_APPS)) return@Action
 
+        val context = manager.getContext()
         val service = QuickSwitchService.instance
+
+        fun usageGranted(): Boolean {
+            val appOps = context.getSystemService(Context.APP_OPS_SERVICE) as AppOpsManager
+            val mode = appOps.checkOpNoThrow(AppOpsManager.OPSTR_GET_USAGE_STATS, android.os.Process.myUid(), context.packageName)
+            return mode == AppOpsManager.MODE_ALLOWED
+        }
+
         if (service != null) {
-            service.switchToPreviousApp()
+            if (usageGranted()) {
+                service.switchToPreviousApp()
+            } else {
+                context.startActivity(Intent(Settings.ACTION_USAGE_ACCESS_SETTINGS).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+            }
         } else {
             Toast.makeText(
-                manager.getContext(),
-                manager.getContext().getString(R.string.action_switch_apps_enable_service),
+                context,
+                context.getString(R.string.action_switch_apps_enable_service),
                 Toast.LENGTH_SHORT
             ).show()
         }

--- a/java/src/org/futo/inputmethod/latin/uix/services/QuickSwitchService.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/services/QuickSwitchService.kt
@@ -1,7 +1,10 @@
 package org.futo.inputmethod.latin.uix.services
 
 import android.accessibilityservice.AccessibilityService
+import android.content.Intent
 import android.view.accessibility.AccessibilityEvent
+import android.app.usage.UsageStatsManager
+import android.app.usage.UsageEvents
 
 class QuickSwitchService : AccessibilityService() {
     override fun onAccessibilityEvent(event: AccessibilityEvent?) {}
@@ -17,7 +20,32 @@ class QuickSwitchService : AccessibilityService() {
     }
 
     fun switchToPreviousApp() {
-        // Use recents action to toggle to the previous app
+        val usm = getSystemService(USAGE_STATS_SERVICE) as UsageStatsManager
+        val end = System.currentTimeMillis()
+        val begin = end - 60_000 // look back up to a minute
+        val events = usm.queryEvents(begin, end)
+        var lastPackage: String? = null
+        var prevPackage: String? = null
+        val event = UsageEvents.Event()
+        while (events.hasNextEvent()) {
+            events.getNextEvent(event)
+            if (event.eventType == UsageEvents.Event.ACTIVITY_RESUMED) {
+                prevPackage = lastPackage
+                lastPackage = event.packageName
+            }
+        }
+
+        val pkgToLaunch = prevPackage
+        if (pkgToLaunch != null && pkgToLaunch != packageName) {
+            val intent = packageManager.getLaunchIntentForPackage(pkgToLaunch)
+            if (intent != null) {
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                startActivity(intent)
+                return
+            }
+        }
+
+        // Fallback to recents screen if no previous app was detected
         performGlobalAction(GLOBAL_ACTION_RECENTS)
     }
 

--- a/java/src/org/futo/inputmethod/latin/uix/services/QuickSwitchService.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/services/QuickSwitchService.kt
@@ -22,21 +22,26 @@ class QuickSwitchService : AccessibilityService() {
     fun switchToPreviousApp() {
         val usm = getSystemService(USAGE_STATS_SERVICE) as UsageStatsManager
         val end = System.currentTimeMillis()
-        val begin = end - 60_000 // look back up to a minute
+        val begin = end - 5 * 60_000 // look back five minutes
         val events = usm.queryEvents(begin, end)
-        var lastPackage: String? = null
-        var prevPackage: String? = null
         val event = UsageEvents.Event()
+
+        var prevPackage: String? = null
+        var lastPackage: String? = null
+        val ignore = setOf(packageName, "com.android.settings")
+
         while (events.hasNextEvent()) {
             events.getNextEvent(event)
-            if (event.eventType == UsageEvents.Event.ACTIVITY_RESUMED) {
-                prevPackage = lastPackage
-                lastPackage = event.packageName
+            if (event.eventType == UsageEvents.Event.ACTIVITY_RESUMED && event.packageName !in ignore) {
+                if (event.packageName != lastPackage) {
+                    prevPackage = lastPackage
+                    lastPackage = event.packageName
+                }
             }
         }
 
         val pkgToLaunch = prevPackage
-        if (pkgToLaunch != null && pkgToLaunch != packageName) {
+        if (pkgToLaunch != null) {
             val intent = packageManager.getLaunchIntentForPackage(pkgToLaunch)
             if (intent != null) {
                 intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)

--- a/java/src/org/futo/inputmethod/latin/uix/services/QuickSwitchService.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/services/QuickSwitchService.kt
@@ -28,11 +28,10 @@ class QuickSwitchService : AccessibilityService() {
 
         var prevPackage: String? = null
         var lastPackage: String? = null
-        val ignore = setOf(packageName, "com.android.settings")
 
         while (events.hasNextEvent()) {
             events.getNextEvent(event)
-            if (event.eventType == UsageEvents.Event.ACTIVITY_RESUMED && event.packageName !in ignore) {
+            if (event.eventType == UsageEvents.Event.ACTIVITY_RESUMED && event.packageName != packageName) {
                 if (event.packageName != lastPackage) {
                     prevPackage = lastPackage
                     lastPackage = event.packageName


### PR DESCRIPTION
## Summary
- intercept BACK key at service level to close clipboard
- remove unusable BackHandler from clipboard UI

## Testing
- `git submodule update --init --recursive`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871636fe9448327a907d85ae9fe0477