### PR TITLE
Fix repeated backup prompt

### DIFF
--- a/java/src/org/futo/inputmethod/latin/uix/PrefKeys.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/PrefKeys.kt
@@ -6,3 +6,8 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
  * Key used to track whether the initial setup flow has been completed.
  */
 val IS_SETUP_COMPLETE = booleanPreferencesKey("is_setup_complete")
+
+/**
+ * Key used to track whether the restore backup prompt has already been shown.
+ */
+val BACKUP_RESTORE_PROMPT_SHOWN = booleanPreferencesKey("backup_restore_prompt_shown")

--- a/java/src/org/futo/inputmethod/latin/uix/settings/Setup.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/Setup.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.material3.CircularProgressIndicator
 import org.futo.inputmethod.latin.uix.IS_SETUP_COMPLETE
+import org.futo.inputmethod.latin.uix.BACKUP_RESTORE_PROMPT_SHOWN
 import org.futo.inputmethod.latin.uix.dataStore
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -150,25 +151,30 @@ fun SetupNavigation(
     val context = LocalContext.current
     val navController = (LocalContext.current as SettingsActivity).navController
     var isSetupComplete by remember { mutableStateOf<Boolean?>(null) }
+    var isBackupPromptShown by remember { mutableStateOf<Boolean?>(null) }
 
     LaunchedEffect(Unit) {
         context.dataStore.data.collect { preferences ->
             isSetupComplete = preferences[IS_SETUP_COMPLETE] ?: false
+            isBackupPromptShown = preferences[BACKUP_RESTORE_PROMPT_SHOWN] ?: false
         }
     }
 
     var currentStep by remember { mutableStateOf(0) }
 
-    LaunchedEffect(isSetupComplete, imeEnabled, imeSelected) {
+    LaunchedEffect(isSetupComplete, imeEnabled, imeSelected, isBackupPromptShown) {
         isSetupComplete?.let {
+            val backupShown = isBackupPromptShown ?: false
             currentStep = if (it) {
                 6 // Go directly to main settings
             } else if (!imeEnabled) {
                 1
             } else if (!imeSelected) {
                 2
-            } else {
+            } else if (!backupShown) {
                 3
+            } else {
+                4
             }
         }
     }

--- a/java/src/org/futo/inputmethod/latin/uix/settings/SetupRestoreBackup.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/SetupRestoreBackup.kt
@@ -13,12 +13,14 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import android.util.Log
+import androidx.datastore.preferences.core.edit
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import androidx.compose.ui.Alignment
@@ -32,6 +34,8 @@ import kotlinx.coroutines.launch
 import org.futo.inputmethod.latin.R
 import org.futo.inputmethod.latin.uix.IMPORT_SETTINGS_REQUEST
 import org.futo.inputmethod.latin.uix.SettingsExporter
+import org.futo.inputmethod.latin.uix.dataStore
+import org.futo.inputmethod.latin.uix.BACKUP_RESTORE_PROMPT_SHOWN
 
 @Composable
 @Preview
@@ -39,6 +43,12 @@ fun SetupRestoreBackup(onFinished: () -> Unit = { }) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     var isLoading by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        context.dataStore.edit { prefs ->
+            prefs[BACKUP_RESTORE_PROMPT_SHOWN] = true
+        }
+    }
 
     val importSettings = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.StartActivityForResult()


### PR DESCRIPTION
## Summary
- track if the restore-backup prompt was shown
- skip the prompt on subsequent app launches

## Testing
- `./gradlew tasks --all` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68726a6f69608327b95a652c0d0b71db