### PR TITLE
Improve restore backup prompt behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Check out the [FUTO Keyboard website](https://keyboard.futo.org/) for downloads 
 - Theme generator handles invalid color codes without crashing.
 - Settings icons use accent variations so each menu item has a unique color.
 - Settings restore now runs on a background IO thread with debug logs for faster restoring.
+- The restore backup prompt is only shown once after installation.
 - AI Reply menu for configuring Groq-powered quick replies using chat completion models fetched from Groq.
   The model picker now lists Llama chat models only.
 - Groq Reply API settings store a separate API key and model for chat completions.

--- a/java/src/org/futo/inputmethod/latin/uix/PrefKeys.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/PrefKeys.kt
@@ -6,3 +6,9 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
  * Key used to track whether the initial setup flow has been completed.
  */
 val IS_SETUP_COMPLETE = booleanPreferencesKey("is_setup_complete")
+
+/**
+ * Key used to ensure the restore backup prompt is only shown once after
+ * installation.
+ */
+val HAS_SEEN_RESTORE_BACKUP_PROMPT = booleanPreferencesKey("seen_restore_backup_prompt")

--- a/java/src/org/futo/inputmethod/latin/uix/settings/Setup.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/Setup.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.material3.CircularProgressIndicator
 import org.futo.inputmethod.latin.uix.IS_SETUP_COMPLETE
+import org.futo.inputmethod.latin.uix.HAS_SEEN_RESTORE_BACKUP_PROMPT
 import org.futo.inputmethod.latin.uix.dataStore
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -150,16 +151,18 @@ fun SetupNavigation(
     val context = LocalContext.current
     val navController = (LocalContext.current as SettingsActivity).navController
     var isSetupComplete by remember { mutableStateOf<Boolean?>(null) }
+    var hasSeenRestoreBackupPrompt by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
         context.dataStore.data.collect { preferences ->
             isSetupComplete = preferences[IS_SETUP_COMPLETE] ?: false
+            hasSeenRestoreBackupPrompt = preferences[HAS_SEEN_RESTORE_BACKUP_PROMPT] ?: false
         }
     }
 
     var currentStep by remember { mutableStateOf(0) }
 
-    LaunchedEffect(isSetupComplete, imeEnabled, imeSelected) {
+    LaunchedEffect(isSetupComplete, imeEnabled, imeSelected, hasSeenRestoreBackupPrompt) {
         isSetupComplete?.let {
             currentStep = if (it) {
                 6 // Go directly to main settings
@@ -167,8 +170,10 @@ fun SetupNavigation(
                 1
             } else if (!imeSelected) {
                 2
-            } else {
+            } else if (!hasSeenRestoreBackupPrompt) {
                 3
+            } else {
+                4
             }
         }
     }

--- a/java/src/org/futo/inputmethod/latin/uix/settings/SetupRestoreBackup.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/SetupRestoreBackup.kt
@@ -32,6 +32,8 @@ import kotlinx.coroutines.launch
 import org.futo.inputmethod.latin.R
 import org.futo.inputmethod.latin.uix.IMPORT_SETTINGS_REQUEST
 import org.futo.inputmethod.latin.uix.SettingsExporter
+import org.futo.inputmethod.latin.uix.HAS_SEEN_RESTORE_BACKUP_PROMPT
+import org.futo.inputmethod.latin.uix.dataStore
 
 @Composable
 @Preview
@@ -39,6 +41,16 @@ fun SetupRestoreBackup(onFinished: () -> Unit = { }) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     var isLoading by remember { mutableStateOf(false) }
+
+    val markSeen: () -> Unit = {
+        scope.launch {
+            context.dataStore.updateData { prefs ->
+                prefs.toMutablePreferences().apply {
+                    this[HAS_SEEN_RESTORE_BACKUP_PROMPT] = true
+                }
+            }
+        }
+    }
 
     val importSettings = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.StartActivityForResult()
@@ -60,10 +72,15 @@ fun SetupRestoreBackup(onFinished: () -> Unit = { }) {
                         Log.e("SetupRestoreBackup", "Error loading settings", e)
                     }
                     isLoading = false
+                    markSeen()
                     onFinished()
                 }
-            } ?: onFinished()
+            } ?: run {
+                markSeen()
+                onFinished()
+            }
         } else {
+            markSeen()
             onFinished()
         }
     }
@@ -105,7 +122,10 @@ fun SetupRestoreBackup(onFinished: () -> Unit = { }) {
                 }
 
                 Button(
-                    onClick = onFinished,
+                    onClick = {
+                        markSeen()
+                        onFinished()
+                    },
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(16.dp)


### PR DESCRIPTION
## Summary
- track if the restore backup prompt has been shown
- skip restore prompt after the first launch
- mark the prompt as seen when restoring or skipping
- document the new behavior in the README

## Testing
- `./gradlew assembleRelease` *(fails: License for package NDK 25.1.8937393 not accepted)*

------
https://chatgpt.com/codex/tasks/task_e_68726a6f69608327b95a652c0d0b71db