### PR TITLE
fix repeated backup prompt

### DIFF
--- a/java/src/org/futo/inputmethod/latin/uix/PrefKeys.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/PrefKeys.kt
@@ -6,3 +6,10 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
  * Key used to track whether the initial setup flow has been completed.
  */
 val IS_SETUP_COMPLETE = booleanPreferencesKey("is_setup_complete")
+
+/**
+ * Indicates whether the user has already been prompted to restore a backup
+ * during the initial setup flow. This prevents repeatedly showing the restore
+ * prompt on every launch if the user dismissed it once.
+ */
+val HAS_SEEN_RESTORE_BACKUP = booleanPreferencesKey("has_seen_restore_backup")

--- a/java/src/org/futo/inputmethod/latin/uix/settings/Setup.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/Setup.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.material3.CircularProgressIndicator
 import org.futo.inputmethod.latin.uix.IS_SETUP_COMPLETE
+import org.futo.inputmethod.latin.uix.HAS_SEEN_RESTORE_BACKUP
 import org.futo.inputmethod.latin.uix.dataStore
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -150,16 +151,18 @@ fun SetupNavigation(
     val context = LocalContext.current
     val navController = (LocalContext.current as SettingsActivity).navController
     var isSetupComplete by remember { mutableStateOf<Boolean?>(null) }
+    var hasSeenRestoreBackup by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) {
         context.dataStore.data.collect { preferences ->
             isSetupComplete = preferences[IS_SETUP_COMPLETE] ?: false
+            hasSeenRestoreBackup = preferences[HAS_SEEN_RESTORE_BACKUP] ?: false
         }
     }
 
     var currentStep by remember { mutableStateOf(0) }
 
-    LaunchedEffect(isSetupComplete, imeEnabled, imeSelected) {
+    LaunchedEffect(isSetupComplete, imeEnabled, imeSelected, hasSeenRestoreBackup) {
         isSetupComplete?.let {
             currentStep = if (it) {
                 6 // Go directly to main settings
@@ -167,8 +170,10 @@ fun SetupNavigation(
                 1
             } else if (!imeSelected) {
                 2
-            } else {
+            } else if (!hasSeenRestoreBackup) {
                 3
+            } else {
+                4
             }
         }
     }

--- a/java/src/org/futo/inputmethod/latin/uix/settings/SetupRestoreBackup.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/SetupRestoreBackup.kt
@@ -32,6 +32,8 @@ import kotlinx.coroutines.launch
 import org.futo.inputmethod.latin.R
 import org.futo.inputmethod.latin.uix.IMPORT_SETTINGS_REQUEST
 import org.futo.inputmethod.latin.uix.SettingsExporter
+import org.futo.inputmethod.latin.uix.HAS_SEEN_RESTORE_BACKUP
+import org.futo.inputmethod.latin.uix.dataStore
 
 @Composable
 @Preview
@@ -60,10 +62,12 @@ fun SetupRestoreBackup(onFinished: () -> Unit = { }) {
                         Log.e("SetupRestoreBackup", "Error loading settings", e)
                     }
                     isLoading = false
+                    context.dataStore.edit { it[HAS_SEEN_RESTORE_BACKUP] = true }
                     onFinished()
                 }
             } ?: onFinished()
         } else {
+            scope.launch { context.dataStore.edit { it[HAS_SEEN_RESTORE_BACKUP] = true } }
             onFinished()
         }
     }
@@ -105,7 +109,10 @@ fun SetupRestoreBackup(onFinished: () -> Unit = { }) {
                 }
 
                 Button(
-                    onClick = onFinished,
+                    onClick = {
+                        scope.launch { context.dataStore.edit { it[HAS_SEEN_RESTORE_BACKUP] = true } }
+                        onFinished()
+                    },
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(16.dp)


### PR DESCRIPTION
## Summary
- track if restore backup prompt was shown
- skip future prompts once user saw it
- set flag after backup import or skip action

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68727f377f088327ac2430a9084387ae