### PR TITLE
Fix repeated backup prompt

### DIFF
--- a/java/src/org/futo/inputmethod/latin/uix/PrefKeys.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/PrefKeys.kt
@@ -6,3 +6,8 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
  * Key used to track whether the initial setup flow has been completed.
  */
 val IS_SETUP_COMPLETE = booleanPreferencesKey("is_setup_complete")
+
+/**
+ * Key used to track whether the user has already been prompted to restore a backup
+ */
+val HAS_SHOWN_BACKUP_PROMPT = booleanPreferencesKey("has_shown_backup_prompt")

--- a/java/src/org/futo/inputmethod/latin/uix/settings/Setup.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/Setup.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.material3.CircularProgressIndicator
 import org.futo.inputmethod.latin.uix.IS_SETUP_COMPLETE
+import org.futo.inputmethod.latin.uix.HAS_SHOWN_BACKUP_PROMPT
 import org.futo.inputmethod.latin.uix.dataStore
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -150,31 +151,36 @@ fun SetupNavigation(
     val context = LocalContext.current
     val navController = (LocalContext.current as SettingsActivity).navController
     var isSetupComplete by remember { mutableStateOf<Boolean?>(null) }
+    var hasShownBackupPrompt by remember { mutableStateOf<Boolean?>(null) }
 
     LaunchedEffect(Unit) {
         context.dataStore.data.collect { preferences ->
             isSetupComplete = preferences[IS_SETUP_COMPLETE] ?: false
+            hasShownBackupPrompt = preferences[HAS_SHOWN_BACKUP_PROMPT] ?: false
         }
     }
 
     var currentStep by remember { mutableStateOf(0) }
 
-    LaunchedEffect(isSetupComplete, imeEnabled, imeSelected) {
+    LaunchedEffect(isSetupComplete, imeEnabled, imeSelected, hasShownBackupPrompt) {
         isSetupComplete?.let {
+            val shownBackup = hasShownBackupPrompt ?: false
             currentStep = if (it) {
                 6 // Go directly to main settings
             } else if (!imeEnabled) {
                 1
             } else if (!imeSelected) {
                 2
-            } else {
+            } else if (!shownBackup) {
                 3
+            } else {
+                4
             }
         }
     }
 
 
-    if (isSetupComplete == null) {
+    if (isSetupComplete == null || hasShownBackupPrompt == null) {
         // Show a loading indicator or a blank screen while checking the flag
         Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
             CircularProgressIndicator()

--- a/java/src/org/futo/inputmethod/latin/uix/settings/SetupRestoreBackup.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/SetupRestoreBackup.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.setValue
 import android.util.Log
 import kotlinx.coroutines.Dispatchers
@@ -32,6 +33,8 @@ import kotlinx.coroutines.launch
 import org.futo.inputmethod.latin.R
 import org.futo.inputmethod.latin.uix.IMPORT_SETTINGS_REQUEST
 import org.futo.inputmethod.latin.uix.SettingsExporter
+import org.futo.inputmethod.latin.uix.dataStore
+import org.futo.inputmethod.latin.uix.HAS_SHOWN_BACKUP_PROMPT
 
 @Composable
 @Preview
@@ -39,6 +42,14 @@ fun SetupRestoreBackup(onFinished: () -> Unit = { }) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     var isLoading by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        context.dataStore.updateData { prefs ->
+            prefs.toMutablePreferences().apply {
+                this[HAS_SHOWN_BACKUP_PROMPT] = true
+            }
+        }
+    }
 
     val importSettings = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.StartActivityForResult()


### PR DESCRIPTION
## Summary
- add `HAS_SHOWN_BACKUP_PROMPT` preference key
- save this flag when the restore backup screen is first displayed
- skip the backup step if it was already shown

## Testing
- `git submodule update --init --recursive`
- `./gradlew assembleRelease` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68727f377f088327ac2430a9084387ae