### PR TITLE
Fix restore backup prompt repeating

### DIFF
--- a/java/src/org/futo/inputmethod/latin/uix/PrefKeys.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/PrefKeys.kt
@@ -6,3 +6,8 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
  * Key used to track whether the initial setup flow has been completed.
  */
 val IS_SETUP_COMPLETE = booleanPreferencesKey("is_setup_complete")
+
+/**
+ * Key used to track whether the restore backup prompt has been shown.
+ */
+val HAS_SHOWN_RESTORE_BACKUP = booleanPreferencesKey("has_shown_restore_backup")

--- a/java/src/org/futo/inputmethod/latin/uix/settings/Setup.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/Setup.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.material3.CircularProgressIndicator
 import org.futo.inputmethod.latin.uix.IS_SETUP_COMPLETE
+import org.futo.inputmethod.latin.uix.HAS_SHOWN_RESTORE_BACKUP
 import org.futo.inputmethod.latin.uix.dataStore
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -150,16 +151,18 @@ fun SetupNavigation(
     val context = LocalContext.current
     val navController = (LocalContext.current as SettingsActivity).navController
     var isSetupComplete by remember { mutableStateOf<Boolean?>(null) }
+    var hasShownRestoreBackup by remember { mutableStateOf<Boolean?>(null) }
 
     LaunchedEffect(Unit) {
         context.dataStore.data.collect { preferences ->
             isSetupComplete = preferences[IS_SETUP_COMPLETE] ?: false
+            hasShownRestoreBackup = preferences[HAS_SHOWN_RESTORE_BACKUP] ?: false
         }
     }
 
     var currentStep by remember { mutableStateOf(0) }
 
-    LaunchedEffect(isSetupComplete, imeEnabled, imeSelected) {
+    LaunchedEffect(isSetupComplete, hasShownRestoreBackup, imeEnabled, imeSelected) {
         isSetupComplete?.let {
             currentStep = if (it) {
                 6 // Go directly to main settings
@@ -167,8 +170,10 @@ fun SetupNavigation(
                 1
             } else if (!imeSelected) {
                 2
-            } else {
+            } else if (hasShownRestoreBackup != true) {
                 3
+            } else {
+                4
             }
         }
     }
@@ -187,6 +192,14 @@ fun SetupNavigation(
             4 -> SetupRequestPermissions { currentStep = 5 }
             5 -> SetupFinish { currentStep = 6 }
             else -> main()
+        }
+    }
+
+    LaunchedEffect(currentStep) {
+        if(currentStep == 3 && hasShownRestoreBackup != true) {
+            context.dataStore.updateData { prefs ->
+                prefs.toMutablePreferences().apply { this[HAS_SHOWN_RESTORE_BACKUP] = true }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a flag for whether restore backup prompt was shown
- use this flag in SetupNavigation to avoid repeatedly showing restore prompt

## Testing
- `./gradlew assembleRelease` *(fails: SDK location not found / licenses not accepted)*

------
https://chatgpt.com/codex/tasks/task_e_68727f377f088327ac2430a9084387ae