### PR TITLE
Avoid repeated backup restore prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Check out the [FUTO Keyboard website](https://keyboard.futo.org/) for downloads 
 - AI Reply menu for configuring Groq-powered quick replies.
 - AI reply generation now streams responses using coroutines for smoother updates.
 - Quick Switch can be toggled in settings and opens your last app directly using usage access (falls back to recents if permission isn't granted).
+- Setup's Grant Permissions button now opens the accessibility settings with the Quick Switch service highlighted.
 - T9 phone layout accessible via the action key for quick number entry.
 - The T9 layout is also listed in the Keyboard Modes menu for easy access.
 - A new persistent T9 keyboard mode lets you keep the phone layout active until changed.

--- a/java/src/org/futo/inputmethod/latin/uix/PrefKeys.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/PrefKeys.kt
@@ -6,3 +6,8 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
  * Key used to track whether the initial setup flow has been completed.
  */
 val IS_SETUP_COMPLETE = booleanPreferencesKey("is_setup_complete")
+/**
+ * Flag used to record that the user has already been offered to restore a backup.
+ * This prevents repeatedly prompting on every app launch.
+ */
+val RESTORE_BACKUP_PROMPT_SHOWN = booleanPreferencesKey("restore_backup_prompt_shown")

--- a/java/src/org/futo/inputmethod/latin/uix/settings/Setup.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/Setup.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.material3.CircularProgressIndicator
 import org.futo.inputmethod.latin.uix.IS_SETUP_COMPLETE
+import org.futo.inputmethod.latin.uix.RESTORE_BACKUP_PROMPT_SHOWN
 import org.futo.inputmethod.latin.uix.dataStore
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -150,16 +151,18 @@ fun SetupNavigation(
     val context = LocalContext.current
     val navController = (LocalContext.current as SettingsActivity).navController
     var isSetupComplete by remember { mutableStateOf<Boolean?>(null) }
+    var backupPromptShown by remember { mutableStateOf<Boolean?>(null) }
 
     LaunchedEffect(Unit) {
         context.dataStore.data.collect { preferences ->
             isSetupComplete = preferences[IS_SETUP_COMPLETE] ?: false
+            backupPromptShown = preferences[RESTORE_BACKUP_PROMPT_SHOWN] ?: false
         }
     }
 
     var currentStep by remember { mutableStateOf(0) }
 
-    LaunchedEffect(isSetupComplete, imeEnabled, imeSelected) {
+    LaunchedEffect(isSetupComplete, backupPromptShown, imeEnabled, imeSelected) {
         isSetupComplete?.let {
             currentStep = if (it) {
                 6 // Go directly to main settings
@@ -167,8 +170,10 @@ fun SetupNavigation(
                 1
             } else if (!imeSelected) {
                 2
-            } else {
+            } else if (backupPromptShown == false) {
                 3
+            } else {
+                4
             }
         }
     }
@@ -182,7 +187,9 @@ fun SetupNavigation(
     } else {
         when (currentStep) {
             1 -> SetupEnableIME { currentStep = 2 }
-            2 -> SetupChangeDefaultIME(doublePackage) { currentStep = 3 }
+            2 -> SetupChangeDefaultIME(doublePackage) {
+                currentStep = if (backupPromptShown == false) 3 else 4
+            }
             3 -> SetupRestoreBackup { currentStep = 4 }
             4 -> SetupRequestPermissions { currentStep = 5 }
             5 -> SetupFinish { currentStep = 6 }

--- a/java/src/org/futo/inputmethod/latin/uix/settings/SetupRequestPermissions.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/SetupRequestPermissions.kt
@@ -38,10 +38,12 @@ fun SetupRequestPermissions(onFinished: () -> Unit = { }) {
                     val component = ComponentName(context, QuickSwitchService::class.java)
                     val intent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                         Intent(Settings.ACTION_ACCESSIBILITY_DETAILS_SETTINGS).apply {
-                            putExtra(Settings.EXTRA_ACCESSIBILITY_SERVICE_COMPONENT_NAME, component.flattenToString())
+                            putExtra(Intent.EXTRA_COMPONENT_NAME, component.flattenToString())
                         }
                     } else {
-                        Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS)
+                        Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS).apply {
+                            putExtra(Intent.EXTRA_COMPONENT_NAME, component.flattenToString())
+                        }
                     }
                     intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                     context.startActivity(intent)

--- a/java/src/org/futo/inputmethod/latin/uix/settings/SetupRequestPermissions.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/SetupRequestPermissions.kt
@@ -1,5 +1,9 @@
 package org.futo.inputmethod.latin.uix.settings
 
+import android.content.ComponentName
+import android.content.Intent
+import android.os.Build
+import android.provider.Settings
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -7,11 +11,13 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.futo.inputmethod.latin.R
+import org.futo.inputmethod.latin.uix.services.QuickSwitchService
 
 @Composable
 @Preview
@@ -26,13 +32,26 @@ fun SetupRequestPermissions(onFinished: () -> Unit = { }) {
                 modifier = Modifier.fillMaxWidth()
             )
 
+            val context = LocalContext.current
             Button(
-                onClick = onFinished,
+                onClick = {
+                    val component = ComponentName(context, QuickSwitchService::class.java)
+                    val intent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                        Intent(Settings.ACTION_ACCESSIBILITY_DETAILS_SETTINGS).apply {
+                            putExtra(Settings.EXTRA_ACCESSIBILITY_SERVICE_COMPONENT_NAME, component.flattenToString())
+                        }
+                    } else {
+                        Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS)
+                    }
+                    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    context.startActivity(intent)
+                    onFinished()
+                },
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(16.dp)
             ) {
-                Text(stringResource(R.string.setup_grant_permissions_button)) // Add this string resource
+                Text(stringResource(R.string.setup_grant_permissions_button))
             }
         }
     }

--- a/java/src/org/futo/inputmethod/latin/uix/settings/SetupRestoreBackup.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/SetupRestoreBackup.kt
@@ -32,6 +32,9 @@ import kotlinx.coroutines.launch
 import org.futo.inputmethod.latin.R
 import org.futo.inputmethod.latin.uix.IMPORT_SETTINGS_REQUEST
 import org.futo.inputmethod.latin.uix.SettingsExporter
+import org.futo.inputmethod.latin.uix.RESTORE_BACKUP_PROMPT_SHOWN
+import org.futo.inputmethod.latin.uix.dataStore
+import androidx.datastore.preferences.core.edit
 
 @Composable
 @Preview
@@ -39,6 +42,15 @@ fun SetupRestoreBackup(onFinished: () -> Unit = { }) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     var isLoading by remember { mutableStateOf(false) }
+
+    val markShownAndFinish = {
+        scope.launch {
+            context.dataStore.edit { prefs ->
+                prefs[RESTORE_BACKUP_PROMPT_SHOWN] = true
+            }
+        }
+        onFinished()
+    }
 
     val importSettings = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.StartActivityForResult()
@@ -60,11 +72,11 @@ fun SetupRestoreBackup(onFinished: () -> Unit = { }) {
                         Log.e("SetupRestoreBackup", "Error loading settings", e)
                     }
                     isLoading = false
-                    onFinished()
+                    markShownAndFinish()
                 }
-            } ?: onFinished()
+            } ?: markShownAndFinish()
         } else {
-            onFinished()
+            markShownAndFinish()
         }
     }
 
@@ -105,7 +117,7 @@ fun SetupRestoreBackup(onFinished: () -> Unit = { }) {
                 }
 
                 Button(
-                    onClick = onFinished,
+                    onClick = markShownAndFinish,
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(16.dp)


### PR DESCRIPTION
## Summary
- add RESTORE_BACKUP_PROMPT_SHOWN preference
- show backup restore step only once
- mark backup restore step complete when finishing the screen

## Testing
- `git submodule update --init --recursive`
- `./gradlew assembleRelease` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68727f377f088327ac2430a9084387ae