### PR TITLE
Fix clipboard search focus persistence

### DIFF
--- a/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryAction.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryAction.kt
@@ -105,11 +105,16 @@ val ClipboardHistoryAction = Action(
 
             @Composable
             override fun WindowContents(keyboardShown: Boolean) {
-                // Test LaunchedEffect stability one level up
+                // Ensure the search field gains focus whenever this window is opened
                 androidx.compose.runtime.LaunchedEffect(Unit) {
-                    android.util.Log.d("ClipboardSearch", "[Test LaunchedEffect(Unit) in ClipboardHistoryAction.WindowContents] Composed.")
+                    manager.setClipboardSearchFocus(true)
                 }
-                ClipboardHistoryWindowContent(manager, clipboardHistoryManager, unlocked, keyboardShown)
+                ClipboardHistoryWindowContent(
+                    manager,
+                    clipboardHistoryManager,
+                    unlocked,
+                    keyboardShown
+                )
             }
         }
     },

--- a/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryComposables.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryComposables.kt
@@ -312,6 +312,15 @@ fun ClipboardHistoryWindowContent(
         }
     }
 
+    // If the manager requests focus, handle it here
+    val requestSearchFocusState = manager.getRequestSearchFocusState()
+    LaunchedEffect(requestSearchFocusState.value) {
+        if (requestSearchFocusState.value) {
+            focusRequester.requestFocus()
+            manager.acknowledgeSearchFocusRequest()
+        }
+    }
+
 
     Column(modifier = Modifier.fillMaxWidth()) {
         // Use TextField with TextFieldValue for better cursor control
@@ -359,8 +368,7 @@ fun ClipboardHistoryWindowContent(
                 }
         )
 
-        // Removed the LaunchedEffect keyed on requestSearchFocusState as it was ineffective.
-        // The focus request is now more direct in onFocusChanged.
+        // Focus requests triggered by the manager are handled via requestSearchFocusState
 
         // Keep this for general composition logging
         LaunchedEffect(Unit) {


### PR DESCRIPTION
## Summary
- ensure clipboard search textbox focuses when opening clipboard history
- watch for focus requests in clipboard search Composable

## Testing
- `git submodule update --init --recursive`
- `./gradlew assembleRelease` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68766d7d18a08327bae0bc3eb1e4247b