### PR TITLE
Fix clipboard search focus handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Check out the [FUTO Keyboard website](https://keyboard.futo.org/) for downloads 
 - AI Reply prompt can be customized from the keyboard or settings and the clipboard text is sent to Groq for context.
 - AI Reply now always uses the most recent clipboard entry when generating a reply, even when launched directly from the actions row.
 - Clipboard history collapses with the Android back key so the keyboard stays open.
+- The clipboard history search box now automatically gains focus when opened again and the back key returns focus to the previous input field.
 - Voice recognition output is normalized so repeated words are removed.
 - Voice input respects the keyboard's caps lock state.
 - Long voice recordings are transcribed in 30 second chunks so earlier audio isn't overwritten.

--- a/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryComposables.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryComposables.kt
@@ -359,8 +359,14 @@ fun ClipboardHistoryWindowContent(
                 }
         )
 
-        // Removed the LaunchedEffect keyed on requestSearchFocusState as it was ineffective.
-        // The focus request is now more direct in onFocusChanged.
+        // Request focus whenever the manager asks for it
+        val requestSearchFocusState = manager.getRequestSearchFocusState()
+        LaunchedEffect(requestSearchFocusState.value) {
+            if (requestSearchFocusState.value) {
+                focusRequester.requestFocus()
+                manager.acknowledgeSearchFocusRequest()
+            }
+        }
 
         // Keep this for general composition logging
         LaunchedEffect(Unit) {


### PR DESCRIPTION
## Summary
- ensure clipboard search field requests focus whenever clipboard history is opened
- document the clipboard search focus behavior in README

## Testing
- `./gradlew tasks --all` *(fails: could not download dependencies due to missing Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68766d7d18a08327bae0bc3eb1e4247b