### PR TITLE
Fix clipboard search focus on reopen

### DIFF
--- a/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryComposables.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryComposables.kt
@@ -290,23 +290,25 @@ fun ClipboardHistoryWindowContent(
         }
     }
     
-    // Focus management effect - only run when the component is first composed or when explicitly requested
-    LaunchedEffect(Unit) {
-        Log.d("ClipboardSearch", "Initial focus setup")
-        // Initial focus request with retry logic
-        var retryCount = 0
-        val maxRetries = 3
-        
-        while (retryCount < maxRetries) {
-            try {
-                focusRequester.requestFocus()
-                Log.d("ClipboardSearch", "Successfully requested focus (attempt ${retryCount + 1})")
-                break
-            } catch (e: IllegalStateException) {
-                Log.e("ClipboardSearch", "Failed to request focus (attempt ${retryCount + 1}): ${e.message}")
-                retryCount++
-                if (retryCount < maxRetries) {
-                    delay(50) // Wait before retry
+    // Focus management effect - request focus whenever the window becomes visible
+    LaunchedEffect(keyboardShown) {
+        if (keyboardShown) {
+            Log.d("ClipboardSearch", "Initial focus setup")
+            // Initial focus request with retry logic
+            var retryCount = 0
+            val maxRetries = 3
+
+            while (retryCount < maxRetries) {
+                try {
+                    focusRequester.requestFocus()
+                    Log.d("ClipboardSearch", "Successfully requested focus (attempt ${retryCount + 1})")
+                    break
+                } catch (e: IllegalStateException) {
+                    Log.e("ClipboardSearch", "Failed to request focus (attempt ${retryCount + 1}): ${e.message}")
+                    retryCount++
+                    if (retryCount < maxRetries) {
+                        delay(50) // Wait before retry
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- ensure clipboard search field grabs focus whenever the clipboard history window is shown

## Testing
- `./gradlew assembleRelease` *(fails: NDK license not accepted)*
- `./gradlew test` *(fails: NDK license not accepted)*

------
https://chatgpt.com/codex/tasks/task_e_68766d7d18a08327bae0bc3eb1e4247b