### PR TITLE
Improve clipboard search focus handling

### DIFF
--- a/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryComposables.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryComposables.kt
@@ -290,26 +290,9 @@ fun ClipboardHistoryWindowContent(
         }
     }
     
-    // Focus management effect - only run when the component is first composed or when explicitly requested
+    // Request focus once when the clipboard history window is shown
     LaunchedEffect(Unit) {
-        Log.d("ClipboardSearch", "Initial focus setup")
-        // Initial focus request with retry logic
-        var retryCount = 0
-        val maxRetries = 3
-        
-        while (retryCount < maxRetries) {
-            try {
-                focusRequester.requestFocus()
-                Log.d("ClipboardSearch", "Successfully requested focus (attempt ${retryCount + 1})")
-                break
-            } catch (e: IllegalStateException) {
-                Log.e("ClipboardSearch", "Failed to request focus (attempt ${retryCount + 1}): ${e.message}")
-                retryCount++
-                if (retryCount < maxRetries) {
-                    delay(50) // Wait before retry
-                }
-            }
-        }
+        focusRequester.requestFocus()
     }
 
 
@@ -332,29 +315,12 @@ fun ClipboardHistoryWindowContent(
                 .fillMaxWidth()
                 .padding(8.dp)
                 .focusRequester(focusRequester)
-                .onFocusChanged { focusState ->
-                    Log.d("ClipboardSearch", "SearchField onFocusChanged: focusState.isFocused=${focusState.isFocused}. Current manager.isClipboardSearchFocused: ${manager.isClipboardSearchFocusedState().value}")
-                    
-                    // Only update the manager's state if there's a real change
+                .onFocusEvent { focusState ->
                     val currentManagerState = manager.isClipboardSearchFocusedState().value
                     if (focusState.isFocused && !currentManagerState) {
-                        Log.d("ClipboardSearch", "SearchField GAINED FOCUS: Updating manager state")
                         manager.setClipboardSearchFocus(true)
                     } else if (!focusState.isFocused && currentManagerState) {
-                        // Before updating the manager, check if this is a temporary focus loss
-                        Log.d("ClipboardSearch", "SearchField LOST FOCUS: Checking if we should update manager state")
-                        
-                        // Only update the manager if this isn't part of a focus change we're handling
-                        view.postDelayed({
-                            val focusedView = view.findFocus()
-                            val hasFocus = focusedView?.hasFocus() ?: false
-                            if (!hasFocus) {
-                                Log.d("ClipboardSearch", "Confirming focus loss, updating manager state")
-                                manager.setClipboardSearchFocus(false)
-                            } else {
-                                Log.d("ClipboardSearch", "Focus was restored, not updating manager state")
-                            }
-                        }, 100) // Small delay to allow focus to stabilize
+                        manager.setClipboardSearchFocus(false)
                     }
                 }
         )


### PR DESCRIPTION
## Summary
- simplify clipboard history search focus handling
- request initial focus once when the clipboard window opens
- update manager focus state directly on focus events

## Testing
- `./gradlew tasks --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68768cf43a108327aab8f9747dd1ff74