### PR TITLE
Auto-focus clipboard search field

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Check out the [FUTO Keyboard website](https://keyboard.futo.org/) for downloads 
 - AI Reply prompt can be customized from the keyboard or settings and the clipboard text is sent to Groq for context.
 - AI Reply now always uses the most recent clipboard entry when generating a reply, even when launched directly from the actions row.
 - Clipboard history collapses with the Android back key so the keyboard stays open.
+- The clipboard history search bar automatically receives focus when opened so typing immediately filters your clips.
 - Voice recognition output is normalized so repeated words are removed.
 - Voice input respects the keyboard's caps lock state.
 - Long voice recordings are transcribed in 30 second chunks so earlier audio isn't overwritten.

--- a/java/src/org/futo/inputmethod/latin/uix/UixManager.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/UixManager.kt
@@ -598,6 +598,12 @@ class UixManager(private val latinIME: LatinIME) {
             ActionRegistry.getActionOverride(latinIME, rawAction)
         }
 
+        if(action == ClipboardHistoryAction) {
+            // Immediately focus the clipboard search field so typed text updates the query
+            isClipboardSearchFocused.value = true
+            requestSearchFocus.value = true
+        }
+
         if (action.windowImpl != null) {
             enterActionWindowView(action)
         } else if (action.simplePressImpl != null) {


### PR DESCRIPTION
## Summary
- focus clipboard search bar when opening clipboard history
- document the auto-focus feature in README

## Testing
- `./gradlew assembleRelease` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876a547ac848327868264d3ee46bc99