### PR TITLE
Focus clipboard search automatically

### DIFF
--- a/java/src/org/futo/inputmethod/latin/uix/UixManager.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/UixManager.kt
@@ -690,6 +690,11 @@ class UixManager(private val latinIME: LatinIME) {
                 R.string.action_menu_opened,
                 latinIME.resources.getString(action.name)
             ))
+
+        // Automatically focus clipboard search bar when opening clipboard history
+        if (action.name == R.string.action_clipboard_manager_title) {
+            keyboardManagerForAction.setClipboardSearchFocus(true)
+        }
     }
 
     private fun returnBackToMainKeyboardViewFromAction(allowSkipClosing: Boolean): Boolean {

--- a/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryComposables.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryComposables.kt
@@ -312,6 +312,15 @@ fun ClipboardHistoryWindowContent(
         }
     }
 
+    // Request focus when manager asks for it (e.g., when opening clipboard history)
+    val requestSearchFocusState = manager.getRequestSearchFocusState()
+    LaunchedEffect(requestSearchFocusState.value) {
+        if (requestSearchFocusState.value) {
+            focusRequester.requestFocus()
+            manager.acknowledgeSearchFocusRequest()
+        }
+    }
+
 
     Column(modifier = Modifier.fillMaxWidth()) {
         // Use TextField with TextFieldValue for better cursor control


### PR DESCRIPTION
## Summary
- trigger clipboard search focus when the history view opens
- request focus from composable when manager asks for it

## Testing
- `./gradlew assembleRelease` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876a547ac848327868264d3ee46bc99