### PR TITLE
Focus clipboard search field

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Check out the [FUTO Keyboard website](https://keyboard.futo.org/) for downloads 
 - AI Reply prompt can be customized from the keyboard or settings and the clipboard text is sent to Groq for context.
 - AI Reply now always uses the most recent clipboard entry when generating a reply, even when launched directly from the actions row.
 - Clipboard history collapses with the Android back key so the keyboard stays open.
+- Clipboard history search field automatically receives focus when opened so you can type immediately.
 - Voice recognition output is normalized so repeated words are removed.
 - Voice input respects the keyboard's caps lock state.
 - Long voice recordings are transcribed in 30 second chunks so earlier audio isn't overwritten.

--- a/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryAction.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryAction.kt
@@ -108,6 +108,8 @@ val ClipboardHistoryAction = Action(
                 // Test LaunchedEffect stability one level up
                 androidx.compose.runtime.LaunchedEffect(Unit) {
                     android.util.Log.d("ClipboardSearch", "[Test LaunchedEffect(Unit) in ClipboardHistoryAction.WindowContents] Composed.")
+                    // Move keyboard focus into the search field when the clipboard history opens
+                    manager.setClipboardSearchFocus(true)
                 }
                 ClipboardHistoryWindowContent(manager, clipboardHistoryManager, unlocked, keyboardShown)
             }


### PR DESCRIPTION
## Summary
- autofocus clipboard search when clipboard history action opens
- document the focus change in README

## Testing
- `./gradlew assembleRelease` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876a547ac848327868264d3ee46bc99