### PR TITLE
Auto-focus clipboard search field

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Check out the [FUTO Keyboard website](https://keyboard.futo.org/) for downloads 
 - AI Reply prompt can be customized from the keyboard or settings and the clipboard text is sent to Groq for context.
 - AI Reply now always uses the most recent clipboard entry when generating a reply, even when launched directly from the actions row.
 - Clipboard history collapses with the Android back key so the keyboard stays open.
+- The clipboard history search bar automatically receives focus when opened so typing immediately filters your clips.
+- Switching to another text field clears the clipboard search focus so typing goes into the new field.
 - Voice recognition output is normalized so repeated words are removed.
 - Voice input respects the keyboard's caps lock state.
 - Long voice recordings are transcribed in 30 second chunks so earlier audio isn't overwritten.

--- a/java/src/org/futo/inputmethod/latin/uix/UixManager.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/UixManager.kt
@@ -115,6 +115,7 @@ import org.futo.inputmethod.latin.suggestions.SuggestionStripViewListener
 import org.futo.inputmethod.latin.uix.actions.ActionEditor
 import org.futo.inputmethod.latin.uix.actions.ActionRegistry
 import org.futo.inputmethod.latin.uix.actions.AllActions
+import org.futo.inputmethod.latin.uix.actions.ClipboardHistoryAction
 import org.futo.inputmethod.latin.uix.actions.KeyboardModeAction
 import org.futo.inputmethod.latin.uix.actions.PersistentEmojiState
 import org.futo.inputmethod.latin.uix.resizing.KeyboardResizers

--- a/java/src/org/futo/inputmethod/latin/uix/UixManager.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/UixManager.kt
@@ -598,6 +598,12 @@ class UixManager(private val latinIME: LatinIME) {
             ActionRegistry.getActionOverride(latinIME, rawAction)
         }
 
+        if(action == ClipboardHistoryAction) {
+            // Immediately focus the clipboard search field so typed text updates the query
+            isClipboardSearchFocused.value = true
+            requestSearchFocus.value = true
+        }
+
         if (action.windowImpl != null) {
             enterActionWindowView(action)
         } else if (action.simplePressImpl != null) {
@@ -1499,6 +1505,14 @@ class UixManager(private val latinIME: LatinIME) {
         }
 
         quickClipState.value = QuickClip.getCurrentState(latinIME)
+
+        // Reset clipboard search focus when a new input connection starts so
+        // typed characters go to the newly selected text field.
+        if (isClipboardSearchFocused.value) {
+            isClipboardSearchFocused.value = false
+            requestSearchFocus.value = false
+            clipboardSearchQuery.value = ""
+        }
     }
 
     fun onInputFinishing() {


### PR DESCRIPTION
## Summary
- focus clipboard search bar when opening clipboard history
- clear search focus if a new text field is selected
- document search focus behavior in README

## Testing
- `./gradlew assembleRelease` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876a547ac848327868264d3ee46bc99