### PR TITLE
Refactor clipboard search handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Check out the [FUTO Keyboard website](https://keyboard.futo.org/) for downloads 
 - AI Reply prompt can be customized from the keyboard or settings and the clipboard text is sent to Groq for context.
 - AI Reply now always uses the most recent clipboard entry when generating a reply, even when launched directly from the actions row.
 - Clipboard history collapses with the Android back key so the keyboard stays open.
+- Clipboard search remembers cursor position and restores it when exiting search.
 - Voice recognition output is normalized so repeated words are removed.
 - Voice input respects the keyboard's caps lock state.
 - Long voice recordings are transcribed in 30 second chunks so earlier audio isn't overwritten.

--- a/java/src/org/futo/inputmethod/latin/inputlogic/InputLogic.java
+++ b/java/src/org/futo/inputmethod/latin/inputlogic/InputLogic.java
@@ -311,7 +311,7 @@ public final class InputLogic {
         if (SpaceState.PHANTOM == mSpaceState) {
             insertAutomaticSpaceIfOptionsAndTextAllow(settingsValues);
         }
-        Log.d("ClipboardSearchInput", "InputLogic.onTextInput: Calling mConnection.commitText(\"" + text + "\"). isClipboardSearchFocused: " + ((org.futo.inputmethod.latin.LatinIME) mLatinIMELegacy.getInputMethodService()).getUixManager().isClipboardSearchFocused().getValue());
+        Log.d("ClipboardSearchInput", "InputLogic.onTextInput: Calling mConnection.commitText(\"" + text + "\"). isClipboardSearchFocused: " + ((org.futo.inputmethod.latin.LatinIME) mLatinIMELegacy.getInputMethodService()).getUixManager().getClipboardSearchState().getValue().getIsActive());
         mConnection.commitText(text, 1);
         StatsUtils.onWordCommitUserTyped(mEnteredText, mWordComposer.isBatchMode());
         mConnection.endBatchEdit();
@@ -392,7 +392,7 @@ public final class InputLogic {
             mSuggestionStripViewAccessor.setNeutralSuggestionStrip();
             inputTransaction.requireShiftUpdate(InputTransaction.SHIFT_UPDATE_NOW);
             resetComposingState(true /* alsoResetLastComposedWord */);
-            Log.d("ClipboardSearchInput", "InputLogic.onPickSuggestionManually (APP_DEFINED): Calling mConnection.commitCompletion. isClipboardSearchFocused: " + ((org.futo.inputmethod.latin.LatinIME) mLatinIMELegacy.getInputMethodService()).getUixManager().isClipboardSearchFocused().getValue());
+            Log.d("ClipboardSearchInput", "InputLogic.onPickSuggestionManually (APP_DEFINED): Calling mConnection.commitCompletion. isClipboardSearchFocused: " + ((org.futo.inputmethod.latin.LatinIME) mLatinIMELegacy.getInputMethodService()).getUixManager().getClipboardSearchState().getValue().getIsActive());
             mConnection.commitCompletion(suggestionInfo.mApplicationSpecifiedCompletionInfo);
             mConnection.endBatchEdit();
             return inputTransaction;
@@ -735,7 +735,7 @@ public final class InputLogic {
         // and we enter both of the following if clauses.
         final CharSequence textToCommit = event.getTextToCommit();
         if (!TextUtils.isEmpty(textToCommit)) {
-            Log.d("ClipboardSearchInput", "InputLogic.handleConsumedEvent: Calling mConnection.commitText(\"" + textToCommit + "\"). isClipboardSearchFocused: " + ((org.futo.inputmethod.latin.LatinIME) mLatinIMELegacy.getInputMethodService()).getUixManager().isClipboardSearchFocused().getValue());
+            Log.d("ClipboardSearchInput", "InputLogic.handleConsumedEvent: Calling mConnection.commitText(\"" + textToCommit + "\"). isClipboardSearchFocused: " + ((org.futo.inputmethod.latin.LatinIME) mLatinIMELegacy.getInputMethodService()).getUixManager().getClipboardSearchState().getValue().getIsActive());
             mConnection.commitText(textToCommit, 1);
             inputTransaction.setDidAffectContents();
         }
@@ -1225,7 +1225,7 @@ public final class InputLogic {
             final int currentKeyboardScriptId) {
         // Corrected access to UixManager
         final org.futo.inputmethod.latin.uix.UixManager uixManager = ((org.futo.inputmethod.latin.LatinIME) mLatinIMELegacy.getInputMethodService()).getUixManager();
-        if (uixManager.isClipboardSearchFocused().getValue()) {
+        if (uixManager.getClipboardSearchState().getValue().getIsActive()) {
             Log.d("ClipboardSearchInput", "InputLogic.handleBackspaceEvent: Clipboard search focused. Handling DELETE.");
             uixManager.getKeyboardManagerForAction().handleClipboardSearchKeyEvent(Constants.CODE_DELETE, 0);
             // We might need to update suggestions/UI after delete for search
@@ -1385,7 +1385,7 @@ public final class InputLogic {
                         - mConnection.getExpectedSelectionStart();
                 mConnection.setSelection(mConnection.getExpectedSelectionEnd(),
                         mConnection.getExpectedSelectionEnd());
-                Log.d("ClipboardSearchInput", "InputLogic.handleBackspaceEvent (selection): Calling mConnection.deleteTextBeforeCursor(" + numCharsDeleted + "). isClipboardSearchFocused: " + uixManager.isClipboardSearchFocused().getValue());
+                Log.d("ClipboardSearchInput", "InputLogic.handleBackspaceEvent (selection): Calling mConnection.deleteTextBeforeCursor(" + numCharsDeleted + "). isClipboardSearchFocused: " + uixManager.getClipboardSearchState().getValue().getIsActive());
                 mConnection.deleteTextBeforeCursor(numCharsDeleted);
                 StatsUtils.onBackspaceSelectedText(numCharsDeleted);
             } else {
@@ -1461,7 +1461,7 @@ public final class InputLogic {
                     }
 
                     Log.d(TAG, "lengthToDelete=" + lengthToDelete + ", textDeleted=" + textDeleted);
-                    Log.d("ClipboardSearchInput", "InputLogic.handleBackspaceEvent (single char): Calling mConnection.deleteTextBeforeCursor(" + lengthToDelete + "). isClipboardSearchFocused: " + uixManager.isClipboardSearchFocused().getValue());
+                    Log.d("ClipboardSearchInput", "InputLogic.handleBackspaceEvent (single char): Calling mConnection.deleteTextBeforeCursor(" + lengthToDelete + "). isClipboardSearchFocused: " + uixManager.getClipboardSearchState().getValue().getIsActive());
                     mConnection.deleteTextBeforeCursor(lengthToDelete);
                     int totalDeletedLength = lengthToDelete;
                     if (mDeleteCount > Constants.DELETE_ACCELERATE_AT) {
@@ -1475,7 +1475,7 @@ public final class InputLogic {
                         if (codePointBeforeCursorToDeleteAgain != Constants.NOT_A_CODE) {
                             final int lengthToDeleteAgain = Character.isSupplementaryCodePoint(
                                     codePointBeforeCursorToDeleteAgain) ? 2 : 1;
-                            Log.d("ClipboardSearchInput", "InputLogic.handleBackspaceEvent (accelerated): Calling mConnection.deleteTextBeforeCursor(" + lengthToDeleteAgain + "). isClipboardSearchFocused: " + uixManager.isClipboardSearchFocused().getValue());
+                            Log.d("ClipboardSearchInput", "InputLogic.handleBackspaceEvent (accelerated): Calling mConnection.deleteTextBeforeCursor(" + lengthToDeleteAgain + "). isClipboardSearchFocused: " + uixManager.getClipboardSearchState().getValue().getIsActive());
                             mConnection.deleteTextBeforeCursor(lengthToDeleteAgain);
                             totalDeletedLength += lengthToDeleteAgain;
                         }
@@ -2124,7 +2124,7 @@ public final class InputLogic {
                         + "\", but before the cursor we found \"" + wordBeforeCursor + "\"");
             }
         }
-        Log.d("ClipboardSearchInput", "InputLogic.revertCommit: Calling mConnection.deleteTextBeforeCursor(" + deleteLength + "). isClipboardSearchFocused: " + ((org.futo.inputmethod.latin.LatinIME) mLatinIMELegacy.getInputMethodService()).getUixManager().isClipboardSearchFocused().getValue());
+        Log.d("ClipboardSearchInput", "InputLogic.revertCommit: Calling mConnection.deleteTextBeforeCursor(" + deleteLength + "). isClipboardSearchFocused: " + ((org.futo.inputmethod.latin.LatinIME) mLatinIMELegacy.getInputMethodService()).getUixManager().getClipboardSearchState().getValue().getIsActive());
         mConnection.deleteTextBeforeCursor(deleteLength);
         if (!TextUtils.isEmpty(committedWord)) {
             unlearnWord(committedWordString, inputTransaction.mSettingsValues,
@@ -2168,7 +2168,7 @@ public final class InputLogic {
         }
 
         if (inputTransaction.mSettingsValues.mSpacingAndPunctuations.mCurrentLanguageHasSpaces) {
-            Log.d("ClipboardSearchInput", "InputLogic.revertCommit: Calling mConnection.commitText(\"" + textToCommit + "\"). isClipboardSearchFocused: " + ((org.futo.inputmethod.latin.LatinIME) mLatinIMELegacy.getInputMethodService()).getUixManager().isClipboardSearchFocused().getValue());
+            Log.d("ClipboardSearchInput", "InputLogic.revertCommit: Calling mConnection.commitText(\"" + textToCommit + "\"). isClipboardSearchFocused: " + ((org.futo.inputmethod.latin.LatinIME) mLatinIMELegacy.getInputMethodService()).getUixManager().getClipboardSearchState().getValue().getIsActive());
             mConnection.commitText(textToCommit, 1);
             if (usePhantomSpace) {
                 mSpaceState = SpaceState.PHANTOM;
@@ -2458,14 +2458,14 @@ public final class InputLogic {
     private void sendKeyCodePoint(final SettingsValues settingsValues, final int codePoint) {
         // Corrected access to UixManager
         final org.futo.inputmethod.latin.uix.UixManager uixManager = ((org.futo.inputmethod.latin.LatinIME) mLatinIMELegacy.getInputMethodService()).getUixManager();
-        if (uixManager.isClipboardSearchFocused().getValue()) {
+        if (uixManager.getClipboardSearchState().getValue().getIsActive()) {
             Log.d("ClipboardSearchInput", "InputLogic.sendKeyCodePoint: Clipboard search focused. CodePoint: " + codePoint);
-            if (Character.isDefined(codePoint) && codePoint != Constants.CODE_ENTER && codePoint != Constants.CODE_SPACE) { // Basic chars, not enter/space yet
+            if (Character.isDefined(codePoint) && codePoint != Constants.CODE_ENTER && codePoint != Constants.CODE_SPACE) {
                 Log.d("ClipboardSearchInput", "InputLogic.sendKeyCodePoint: Appending char to search: \"" + StringUtils.newSingleCodePointString(codePoint) + "\"");
-                uixManager.getKeyboardManagerForAction().setClipboardSearchQuery(uixManager.getKeyboardManagerForAction().getClipboardSearchQuery() + StringUtils.newSingleCodePointString(codePoint));
+                uixManager.getKeyboardManagerForAction().commitTextToSearch(StringUtils.newSingleCodePointString(codePoint));
             } else if (codePoint == Constants.CODE_SPACE) {
                 Log.d("ClipboardSearchInput", "InputLogic.sendKeyCodePoint: Appending space to search.");
-                uixManager.getKeyboardManagerForAction().setClipboardSearchQuery(uixManager.getKeyboardManagerForAction().getClipboardSearchQuery() + " ");
+                uixManager.getKeyboardManagerForAction().commitTextToSearch(" ");
             }
             // TODO: Handle Enter for search if needed, or let it be handled by higher-level onCodeInput
             return;
@@ -2479,7 +2479,7 @@ public final class InputLogic {
             // relying on this behavior so we continue to support it for older apps.
             sendDownUpKeyEvent(KeyEvent.KEYCODE_ENTER, 0);
         } else {
-            Log.d("ClipboardSearchInput", "InputLogic.sendKeyCodePoint: ELSE Calling mConnection.commitText(\"" + StringUtils.newSingleCodePointString(codePoint) + "\"). isClipboardSearchFocused: " + uixManager.isClipboardSearchFocused().getValue());
+            Log.d("ClipboardSearchInput", "InputLogic.sendKeyCodePoint: ELSE Calling mConnection.commitText(\"" + StringUtils.newSingleCodePointString(codePoint) + "\"). isClipboardSearchFocused: " + uixManager.getClipboardSearchState().getValue().getIsActive());
             mConnection.commitText(StringUtils.newSingleCodePointString(codePoint), 1);
         }
     }
@@ -2680,7 +2680,7 @@ public final class InputLogic {
             Log.d(TAG, "commitChosenWord() : NgramContext = " + ngramContext);
             startTimeMillis = System.currentTimeMillis();
         }
-        Log.d("ClipboardSearchInput", "InputLogic.commitChosenWord: Calling mConnection.commitText(\"" + chosenWordWithSuggestions + "\"). isClipboardSearchFocused: " + ((org.futo.inputmethod.latin.LatinIME) mLatinIMELegacy.getInputMethodService()).getUixManager().isClipboardSearchFocused().getValue());
+        Log.d("ClipboardSearchInput", "InputLogic.commitChosenWord: Calling mConnection.commitText(\"" + chosenWordWithSuggestions + "\"). isClipboardSearchFocused: " + ((org.futo.inputmethod.latin.LatinIME) mLatinIMELegacy.getInputMethodService()).getUixManager().getClipboardSearchState().getValue().getIsActive());
         mConnection.commitText(chosenWordWithSuggestions, 1);
         if (DebugFlags.DEBUG_ENABLED) {
             long runTimeMillis = System.currentTimeMillis() - startTimeMillis;
@@ -2812,7 +2812,7 @@ public final class InputLogic {
                     Spanned.SPAN_EXCLUSIVE_EXCLUSIVE | Spanned.SPAN_COMPOSING);
             composingTextToBeSet = spannable;
         }
-        Log.d("ClipboardSearchInput", "InputLogic: Calling mConnection.setComposingText(\"" + newComposingText + "\"). isClipboardSearchFocused: " + ((org.futo.inputmethod.latin.LatinIME) mLatinIMELegacy.getInputMethodService()).getUixManager().isClipboardSearchFocused().getValue());
+        Log.d("ClipboardSearchInput", "InputLogic: Calling mConnection.setComposingText(\"" + newComposingText + "\"). isClipboardSearchFocused: " + ((org.futo.inputmethod.latin.LatinIME) mLatinIMELegacy.getInputMethodService()).getUixManager().getClipboardSearchState().getValue().getIsActive());
         mConnection.setComposingText(composingTextToBeSet, newCursorPosition);
     }
 

--- a/java/src/org/futo/inputmethod/latin/uix/Action.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/Action.kt
@@ -109,8 +109,8 @@ interface KeyboardManagerForAction {
     fun setClipboardSearchQuery(query: String)
     fun handleClipboardSearchKeyEvent(keyCode: Int, metaState: Int): Boolean // Returns true if handled
     fun isClipboardSearchFocusedState(): androidx.compose.runtime.State<Boolean>
-    fun getRequestSearchFocusState(): androidx.compose.runtime.State<Boolean>
-    fun acknowledgeSearchFocusRequest()
+    fun commitTextToSearch(text: String)
+    fun getOriginalInputConnection(): InputConnection?
 }
 
 enum class CloseResult {

--- a/java/src/org/futo/inputmethod/latin/uix/ClipboardSearchState.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/ClipboardSearchState.kt
@@ -1,0 +1,13 @@
+package org.futo.inputmethod.latin.uix
+
+import android.view.inputmethod.InputConnection
+
+/**
+ * Holds state related to clipboard search mode.
+ */
+data class ClipboardSearchState(
+    val isActive: Boolean = false,
+    val query: String = "",
+    val originalCursorPosition: Int? = null,
+    val originalInputConnection: InputConnection? = null
+)

--- a/java/src/org/futo/inputmethod/latin/uix/UixManager.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/UixManager.kt
@@ -468,55 +468,92 @@ class UixActionKeyboardManager(val uixManager: UixManager, val latinIME: LatinIM
     override fun getSuggestionBlacklist(): SuggestionBlacklist = latinIME.suggestionBlacklist
 
     override fun setClipboardSearchFocus(isFocused: Boolean) {
-        Log.d("ClipboardSearch", "UixActionKeyboardManager.setClipboardSearchFocus: new isFocused = $isFocused, current uixManager.isClipboardSearchFocused = ${uixManager.isClipboardSearchFocused.value}")
-        val oldFocusedState = uixManager.isClipboardSearchFocused.value
-        uixManager.isClipboardSearchFocused.value = isFocused
+        Log.d("ClipboardSearch", "setClipboardSearchFocus: $isFocused")
 
-        if (isFocused && !oldFocusedState) {
-            // Tentative Fix: Ensure main keyboard area is not generally hidden when search gets focus
+        val currentState = uixManager.clipboardSearchState.value
+
+        if (isFocused && !currentState.isActive) {
+            val originalCursor = try {
+                latinIME.currentInputConnection?.getTextBeforeCursor(1000, 0)?.length
+            } catch (e: Exception) {
+                Log.w("ClipboardSearch", "Failed to get cursor position", e)
+                null
+            }
+
+            uixManager.clipboardSearchState.value = ClipboardSearchState(
+                isActive = true,
+                query = "",
+                originalCursorPosition = originalCursor,
+                originalInputConnection = latinIME.currentInputConnection
+            )
+
             uixManager.mainKeyboardHidden.value = false
-            Log.d("ClipboardSearch", "UixActionKeyboardManager.setClipboardSearchFocus: Became focused. Setting requestSearchFocus = true")
-            uixManager.requestSearchFocus.value = true // Trigger the focus request
-        } else if (!isFocused && oldFocusedState) {
-            // Clear search query when focus is lost from search field
-            uixManager.clipboardSearchQuery.value = ""
-            Log.d("ClipboardSearch", "UixActionKeyboardManager.setClipboardSearchFocus: Lost focus.")
-            // Ensure request is reset if focus is lost externally
-            if(uixManager.requestSearchFocus.value) uixManager.requestSearchFocus.value = false
+
+        } else if (!isFocused && currentState.isActive) {
+            uixManager.clipboardSearchState.value = ClipboardSearchState()
+
+            currentState.originalCursorPosition?.let { position ->
+                currentState.originalInputConnection?.let { connection ->
+                    try {
+                        val currentText = connection.getTextBeforeCursor(1000, 0)
+                        if (currentText != null && position <= currentText.length) {
+                            connection.setSelection(position, position)
+                        }
+                    } catch (e: Exception) {
+                        Log.w("ClipboardSearch", "Failed to restore cursor position", e)
+                    }
+                }
+            }
         }
-        Log.d("ClipboardSearch", "UixActionKeyboardManager.setClipboardSearchFocus: new uixManager.isClipboardSearchFocused = ${uixManager.isClipboardSearchFocused.value}, requestSearchFocus = ${uixManager.requestSearchFocus.value}")
     }
 
     override fun getClipboardSearchQuery(): String {
-        return uixManager.clipboardSearchQuery.value
+        return uixManager.clipboardSearchState.value.query
     }
 
     override fun setClipboardSearchQuery(query: String) {
-        uixManager.clipboardSearchQuery.value = query
+        val currentState = uixManager.clipboardSearchState.value
+        if (currentState.isActive) {
+            uixManager.clipboardSearchState.value = currentState.copy(query = query)
+        }
     }
 
     override fun handleClipboardSearchKeyEvent(keyCode: Int, metaState: Int): Boolean {
-        if (keyCode == Constants.CODE_DELETE) {
-            val currentQuery = uixManager.clipboardSearchQuery.value
-            if (currentQuery.isNotEmpty()) {
-                uixManager.clipboardSearchQuery.value = currentQuery.substring(0, currentQuery.length - 1)
+        val currentState = uixManager.clipboardSearchState.value
+        if (!currentState.isActive) return false
+
+        when (keyCode) {
+            Constants.CODE_DELETE -> {
+                if (currentState.query.isNotEmpty()) {
+                    uixManager.clipboardSearchState.value = currentState.copy(
+                        query = currentState.query.dropLast(1)
+                    )
+                }
+                return true
             }
-            return true
+            Constants.CODE_ENTER -> {
+                setClipboardSearchFocus(false)
+                return true
+            }
         }
-        // Could handle other keys like arrows if needed, but text commit should handle characters.
         return false
     }
 
     override fun isClipboardSearchFocusedState(): androidx.compose.runtime.State<Boolean> {
-        return uixManager.isClipboardSearchFocused
+        return derivedStateOf { uixManager.clipboardSearchState.value.isActive }
     }
 
-    override fun getRequestSearchFocusState(): androidx.compose.runtime.State<Boolean> {
-        return uixManager.requestSearchFocus
+    override fun commitTextToSearch(text: String) {
+        val currentState = uixManager.clipboardSearchState.value
+        if (currentState.isActive) {
+            uixManager.clipboardSearchState.value = currentState.copy(
+                query = currentState.query + text
+            )
+        }
     }
 
-    override fun acknowledgeSearchFocusRequest() {
-        uixManager.requestSearchFocus.value = false
+    override fun getOriginalInputConnection(): InputConnection? {
+        return uixManager.clipboardSearchState.value.originalInputConnection
     }
 }
 
@@ -578,9 +615,9 @@ class UixManager(private val latinIME: LatinIME) {
     val foldingOptions = mutableStateOf(FoldingOptions(null))
 
     var isInputOverridden = mutableStateOf(false)
-    val isClipboardSearchFocused: MutableState<Boolean> = mutableStateOf(false)
-    val clipboardSearchQuery: MutableState<String> = mutableStateOf("")
-    val requestSearchFocus: MutableState<Boolean> = mutableStateOf(false) // New state
+    // Consolidated clipboard search related state
+    val clipboardSearchState: MutableState<ClipboardSearchState> =
+        mutableStateOf(ClipboardSearchState())
 
     var currWindowActionWindow: MutableState<ActionWindow?> = mutableStateOf(null)
 
@@ -715,10 +752,8 @@ class UixManager(private val latinIME: LatinIME) {
         keyboardManagerForAction.announce(latinIME.getString(R.string.action_menu_closed, name))
 
         // Ensure clipboard search mode is fully reset when leaving an action
-        if(isClipboardSearchFocused.value) {
-            isClipboardSearchFocused.value = false
-            clipboardSearchQuery.value = ""
-            requestSearchFocus.value = false
+        if(clipboardSearchState.value.isActive) {
+            clipboardSearchState.value = ClipboardSearchState()
         }
         return true
     }
@@ -1211,19 +1246,14 @@ class UixManager(private val latinIME: LatinIME) {
 
             KeyboardWindowSelector { gap ->
                 Column {
-                    val isClipboardSearchModeActive = isClipboardSearchFocused.value &&
-                            currWindowAction.value?.name == R.string.action_clipboard_manager_title // Check if it's clipboard history action
-                    Log.d("ClipboardSearch", "UixManager.Content: isClipboardSearchFocused=${isClipboardSearchFocused.value}, currAction=${currWindowAction.value?.name}, isClipboardSearchModeActive=$isClipboardSearchModeActive, mainKeyboardHidden=${mainKeyboardHidden.value}")
+                    val clipboardSearchActive = clipboardSearchState.value.isActive &&
+                            currWindowAction.value?.name == R.string.action_clipboard_manager_title
+                    Log.d("ClipboardSearch", "Content: clipboardSearchActive=$clipboardSearchActive")
 
-                    if (isClipboardSearchModeActive) {
+                    if (clipboardSearchActive) {
                         // Mode: Clipboard History with Search Focused
-                        // 1. Show Clipboard Action Window (includes search bar)
                         currWindowActionWindow.value?.let { ActionViewWithHeader(it) }
-
-                        // 2. NO standard action bar/suggestion strip for the main keyboard
-                        //    The LegacyKeyboardView will be shown below.
-                        //    The 'gap' might be irrelevant here or could be a specific small spacer.
-                        Spacer(modifier = Modifier.height(0.dp)) // Minimal or no gap
+                        Spacer(modifier = Modifier.height(2.dp))
 
                     } else if (currWindowActionWindow.value != null) {
                         // Mode: Other Action Window is active
@@ -1236,13 +1266,12 @@ class UixManager(private val latinIME: LatinIME) {
                     }
 
                     // Determine visibility of the LegacyKeyboardView (the actual keys)
-                    val legacyKeyboardActuallyHidden = if (isClipboardSearchModeActive) {
-                        false // Force keyboard to be shown for clipboard search
+                    val shouldHideKeyboard = if (clipboardSearchActive) {
+                        false
                     } else {
                         isMainKeyboardHidden.value // Standard visibility logic for other action windows
                     }
-                    Log.d("ClipboardSearch", "UixManager.Content: legacyKeyboardActuallyHidden=$legacyKeyboardActuallyHidden")
-                    latinIME.LegacyKeyboardView(hidden = legacyKeyboardActuallyHidden)
+                    latinIME.LegacyKeyboardView(hidden = shouldHideKeyboard)
 
                     if(latinIME.size.value !is FloatingKeyboardSize) {
                         Spacer(Modifier.height(navBarHeight()))
@@ -1340,6 +1369,11 @@ class UixManager(private val latinIME: LatinIME) {
 
     fun closeActionWindow(allowSkipClosing: Boolean = false) {
         if(returnBackToMainKeyboardViewFromAction(allowSkipClosing) == false) return
+
+        // Reset clipboard search state when closing action window
+        if (clipboardSearchState.value.isActive) {
+            keyboardManagerForAction.setClipboardSearchFocus(false)
+        }
 
         // Reset any typeface override as they're not supposed to persist outside of an active
         // action window


### PR DESCRIPTION
## Summary
- introduce `ClipboardSearchState` to manage clipboard search mode
- unify clipboard search state in `UixManager`
- update `UixActionKeyboardManager` methods for new state
- adjust `InputLogic` to use new APIs
- document clipboard cursor restore feature in README

## Testing
- `git submodule update --init --recursive`
- `./gradlew assembleRelease` *(fails: SDK licenses not accepted)*

------
https://chatgpt.com/codex/tasks/task_e_68791c78c1ec8327920a8ba2029de2fd