### PR TITLE
Improve clipboard search state handling

### DIFF
--- a/java/src/org/futo/inputmethod/latin/uix/Action.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/Action.kt
@@ -109,8 +109,6 @@ interface KeyboardManagerForAction {
     fun setClipboardSearchQuery(query: String)
     fun handleClipboardSearchKeyEvent(keyCode: Int, metaState: Int): Boolean // Returns true if handled
     fun isClipboardSearchFocusedState(): androidx.compose.runtime.State<Boolean>
-    fun getRequestSearchFocusState(): androidx.compose.runtime.State<Boolean>
-    fun acknowledgeSearchFocusRequest()
 }
 
 enum class CloseResult {

--- a/java/src/org/futo/inputmethod/latin/uix/UixManager.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/UixManager.kt
@@ -57,6 +57,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.State
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -468,55 +469,96 @@ class UixActionKeyboardManager(val uixManager: UixManager, val latinIME: LatinIM
     override fun getSuggestionBlacklist(): SuggestionBlacklist = latinIME.suggestionBlacklist
 
     override fun setClipboardSearchFocus(isFocused: Boolean) {
-        Log.d("ClipboardSearch", "UixActionKeyboardManager.setClipboardSearchFocus: new isFocused = $isFocused, current uixManager.isClipboardSearchFocused = ${uixManager.isClipboardSearchFocused.value}")
-        val oldFocusedState = uixManager.isClipboardSearchFocused.value
-        uixManager.isClipboardSearchFocused.value = isFocused
+        Log.d("ClipboardSearch", "setClipboardSearchFocus: $isFocused")
 
-        if (isFocused && !oldFocusedState) {
-            // Tentative Fix: Ensure main keyboard area is not generally hidden when search gets focus
+        val currentState = uixManager.clipboardSearchState.value
+
+        if (isFocused && !currentState.isActive) {
+            // Entering search mode
+            val originalCursor = try {
+                latinIME.currentInputConnection?.getTextBeforeCursor(1000, 0)?.length
+            } catch (e: Exception) {
+                Log.w("ClipboardSearch", "Failed to get cursor position", e)
+                null
+            }
+
+            uixManager.clipboardSearchState.value = ClipboardSearchState(
+                isActive = true,
+                query = "",
+                originalCursorPosition = originalCursor,
+                originalInputConnection = latinIME.currentInputConnection
+            )
+
+            // Ensure keyboard is visible for search
             uixManager.mainKeyboardHidden.value = false
-            Log.d("ClipboardSearch", "UixActionKeyboardManager.setClipboardSearchFocus: Became focused. Setting requestSearchFocus = true")
-            uixManager.requestSearchFocus.value = true // Trigger the focus request
-        } else if (!isFocused && oldFocusedState) {
-            // Clear search query when focus is lost from search field
-            uixManager.clipboardSearchQuery.value = ""
-            Log.d("ClipboardSearch", "UixActionKeyboardManager.setClipboardSearchFocus: Lost focus.")
-            // Ensure request is reset if focus is lost externally
-            if(uixManager.requestSearchFocus.value) uixManager.requestSearchFocus.value = false
+
+        } else if (!isFocused && currentState.isActive) {
+            // Exiting search mode
+            uixManager.clipboardSearchState.value = ClipboardSearchState()
+
+            // Restore cursor position if we have the original connection
+            currentState.originalCursorPosition?.let { position ->
+                currentState.originalInputConnection?.let { connection ->
+                    try {
+                        val currentText = connection.getTextBeforeCursor(1000, 0)
+                        if (currentText != null && position <= currentText.length) {
+                            connection.setSelection(position, position)
+                        }
+                    } catch (e: Exception) {
+                        Log.w("ClipboardSearch", "Failed to restore cursor position", e)
+                    }
+                }
+            }
         }
-        Log.d("ClipboardSearch", "UixActionKeyboardManager.setClipboardSearchFocus: new uixManager.isClipboardSearchFocused = ${uixManager.isClipboardSearchFocused.value}, requestSearchFocus = ${uixManager.requestSearchFocus.value}")
     }
 
     override fun getClipboardSearchQuery(): String {
-        return uixManager.clipboardSearchQuery.value
+        return uixManager.clipboardSearchState.value.query
     }
 
     override fun setClipboardSearchQuery(query: String) {
-        uixManager.clipboardSearchQuery.value = query
+        val currentState = uixManager.clipboardSearchState.value
+        if (currentState.isActive) {
+            uixManager.clipboardSearchState.value = currentState.copy(query = query)
+        }
     }
 
     override fun handleClipboardSearchKeyEvent(keyCode: Int, metaState: Int): Boolean {
-        if (keyCode == Constants.CODE_DELETE) {
-            val currentQuery = uixManager.clipboardSearchQuery.value
-            if (currentQuery.isNotEmpty()) {
-                uixManager.clipboardSearchQuery.value = currentQuery.substring(0, currentQuery.length - 1)
+        val currentState = uixManager.clipboardSearchState.value
+        if (!currentState.isActive) return false
+
+        when (keyCode) {
+            Constants.CODE_DELETE -> {
+                if (currentState.query.isNotEmpty()) {
+                    uixManager.clipboardSearchState.value = currentState.copy(
+                        query = currentState.query.dropLast(1)
+                    )
+                }
+                return true
             }
-            return true
+            Constants.CODE_ENTER -> {
+                setClipboardSearchFocus(false)
+                return true
+            }
         }
-        // Could handle other keys like arrows if needed, but text commit should handle characters.
         return false
     }
 
     override fun isClipboardSearchFocusedState(): androidx.compose.runtime.State<Boolean> {
-        return uixManager.isClipboardSearchFocused
+        return derivedStateOf { uixManager.clipboardSearchState.value.isActive }
     }
 
-    override fun getRequestSearchFocusState(): androidx.compose.runtime.State<Boolean> {
-        return uixManager.requestSearchFocus
+    fun commitTextToSearch(text: String) {
+        val currentState = uixManager.clipboardSearchState.value
+        if (currentState.isActive) {
+            uixManager.clipboardSearchState.value = currentState.copy(
+                query = currentState.query + text
+            )
+        }
     }
 
-    override fun acknowledgeSearchFocusRequest() {
-        uixManager.requestSearchFocus.value = false
+    fun getOriginalInputConnection(): InputConnection? {
+        return uixManager.clipboardSearchState.value.originalInputConnection
     }
 }
 
@@ -524,6 +566,13 @@ data class ActiveDialogRequest(
     val text: String,
     val options: List<DialogRequestItem>,
     val onCancel: () -> Unit
+)
+
+data class ClipboardSearchState(
+    val isActive: Boolean = false,
+    val query: String = "",
+    val originalCursorPosition: Int? = null,
+    val originalInputConnection: InputConnection? = null
 )
 
 @RequiresOptIn(level = RequiresOptIn.Level.ERROR, message = "This is for debug purposes only.")
@@ -578,9 +627,11 @@ class UixManager(private val latinIME: LatinIME) {
     val foldingOptions = mutableStateOf(FoldingOptions(null))
 
     var isInputOverridden = mutableStateOf(false)
-    val isClipboardSearchFocused: MutableState<Boolean> = mutableStateOf(false)
-    val clipboardSearchQuery: MutableState<String> = mutableStateOf("")
-    val requestSearchFocus: MutableState<Boolean> = mutableStateOf(false) // New state
+    val clipboardSearchState: MutableState<ClipboardSearchState> = mutableStateOf(ClipboardSearchState())
+
+    @JvmName("isClipboardSearchFocused")
+    fun isClipboardSearchFocused(): State<Boolean> =
+        derivedStateOf { clipboardSearchState.value.isActive }
 
     var currWindowActionWindow: MutableState<ActionWindow?> = mutableStateOf(null)
 
@@ -715,10 +766,8 @@ class UixManager(private val latinIME: LatinIME) {
         keyboardManagerForAction.announce(latinIME.getString(R.string.action_menu_closed, name))
 
         // Ensure clipboard search mode is fully reset when leaving an action
-        if(isClipboardSearchFocused.value) {
-            isClipboardSearchFocused.value = false
-            clipboardSearchQuery.value = ""
-            requestSearchFocus.value = false
+        if(clipboardSearchState.value.isActive) {
+            clipboardSearchState.value = ClipboardSearchState()
         }
         return true
     }
@@ -1211,19 +1260,14 @@ class UixManager(private val latinIME: LatinIME) {
 
             KeyboardWindowSelector { gap ->
                 Column {
-                    val isClipboardSearchModeActive = isClipboardSearchFocused.value &&
-                            currWindowAction.value?.name == R.string.action_clipboard_manager_title // Check if it's clipboard history action
-                    Log.d("ClipboardSearch", "UixManager.Content: isClipboardSearchFocused=${isClipboardSearchFocused.value}, currAction=${currWindowAction.value?.name}, isClipboardSearchModeActive=$isClipboardSearchModeActive, mainKeyboardHidden=${mainKeyboardHidden.value}")
+                    val clipboardSearchActive = clipboardSearchState.value.isActive &&
+                            currWindowAction.value?.name == R.string.action_clipboard_manager_title
 
-                    if (isClipboardSearchModeActive) {
-                        // Mode: Clipboard History with Search Focused
-                        // 1. Show Clipboard Action Window (includes search bar)
+                    Log.d("ClipboardSearch", "Content: clipboardSearchActive=$clipboardSearchActive")
+
+                    if (clipboardSearchActive) {
                         currWindowActionWindow.value?.let { ActionViewWithHeader(it) }
-
-                        // 2. NO standard action bar/suggestion strip for the main keyboard
-                        //    The LegacyKeyboardView will be shown below.
-                        //    The 'gap' might be irrelevant here or could be a specific small spacer.
-                        Spacer(modifier = Modifier.height(0.dp)) // Minimal or no gap
+                        Spacer(modifier = Modifier.height(2.dp))
 
                     } else if (currWindowActionWindow.value != null) {
                         // Mode: Other Action Window is active
@@ -1235,14 +1279,13 @@ class UixManager(private val latinIME: LatinIME) {
                         Spacer(modifier = Modifier.height(gap))
                     }
 
-                    // Determine visibility of the LegacyKeyboardView (the actual keys)
-                    val legacyKeyboardActuallyHidden = if (isClipboardSearchModeActive) {
-                        false // Force keyboard to be shown for clipboard search
+                    val shouldHideKeyboard = if (clipboardSearchActive) {
+                        false
                     } else {
-                        isMainKeyboardHidden.value // Standard visibility logic for other action windows
+                        isMainKeyboardHidden.value
                     }
-                    Log.d("ClipboardSearch", "UixManager.Content: legacyKeyboardActuallyHidden=$legacyKeyboardActuallyHidden")
-                    latinIME.LegacyKeyboardView(hidden = legacyKeyboardActuallyHidden)
+
+                    latinIME.LegacyKeyboardView(hidden = shouldHideKeyboard)
 
                     if(latinIME.size.value !is FloatingKeyboardSize) {
                         Spacer(Modifier.height(navBarHeight()))
@@ -1340,6 +1383,11 @@ class UixManager(private val latinIME: LatinIME) {
 
     fun closeActionWindow(allowSkipClosing: Boolean = false) {
         if(returnBackToMainKeyboardViewFromAction(allowSkipClosing) == false) return
+
+        // Reset clipboard search state when closing action window
+        if(clipboardSearchState.value.isActive) {
+            keyboardManagerForAction.setClipboardSearchFocus(false)
+        }
 
         // Reset any typeface override as they're not supposed to persist outside of an active
         // action window

--- a/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryComposables.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryComposables.kt
@@ -36,7 +36,6 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -48,6 +47,8 @@ import org.futo.inputmethod.latin.common.Constants
 import org.futo.inputmethod.latin.uix.DialogRequestItem
 // Replaced UixManager with KeyboardManagerForAction as per Action.kt definition
 import org.futo.inputmethod.latin.uix.KeyboardManagerForAction
+import org.futo.inputmethod.latin.uix.UixActionKeyboardManager
+import org.futo.inputmethod.latin.uix.ClipboardSearchState
 import org.futo.inputmethod.latin.uix.getSetting
 import org.futo.inputmethod.latin.uix.settings.ScrollableList
 import org.futo.inputmethod.latin.uix.settings.pages.ParagraphText
@@ -60,9 +61,9 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.TextFieldValue
-import androidx.compose.ui.text.input.OffsetMapping
-import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.material3.KeyboardActions
+import androidx.compose.material3.KeyboardOptions
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.withStyle
 import kotlinx.coroutines.delay
 import kotlin.math.roundToInt
@@ -262,101 +263,28 @@ fun ClipboardHistoryWindowContent(
     val view = LocalView.current
     val context = LocalContext.current
     val clipboardHistoryEnabledState = useDataStore(ClipboardHistoryEnabled, blocking = true)
-    val focusRequester = remember { FocusRequester() }
-    // val localFocusManager = LocalFocusManager.current // Not strictly needed if we change focus logic
+    val searchFocusRequester = remember { FocusRequester() }
+    val searchState = (manager as? UixActionKeyboardManager)?.uixManager?.clipboardSearchState?.value ?: ClipboardSearchState()
 
-
-    // Use TextFieldValue to manage cursor position
-    var textFieldValue by remember {
-        mutableStateOf(TextFieldValue(manager.getClipboardSearchQuery()))
-    }
-    
-    // Track if we're currently updating from the manager to prevent loops
-    var isUpdatingFromManager by remember { mutableStateOf(false) }
-    
-    // Sync with manager's state
-    LaunchedEffect(manager.getClipboardSearchQuery()) {
-        if (!isUpdatingFromManager) {
-            val currentText = textFieldValue.text
-            val managerText = manager.getClipboardSearchQuery()
-            
-            if (currentText != managerText) {
-                // Update the text and move cursor to the end
-                textFieldValue = TextFieldValue(
-                    text = managerText,
-                    selection = androidx.compose.ui.text.TextRange(managerText.length)
-                )
-            }
-        }
-    }
-    
-    // Focus management effect - only run when the component is first composed or when explicitly requested
     LaunchedEffect(Unit) {
-        Log.d("ClipboardSearch", "Initial focus setup")
-        // Initial focus request with retry logic
-        var retryCount = 0
-        val maxRetries = 3
-        
-        while (retryCount < maxRetries) {
-            try {
-                focusRequester.requestFocus()
-                Log.d("ClipboardSearch", "Successfully requested focus (attempt ${retryCount + 1})")
-                break
-            } catch (e: IllegalStateException) {
-                Log.e("ClipboardSearch", "Failed to request focus (attempt ${retryCount + 1}): ${e.message}")
-                retryCount++
-                if (retryCount < maxRetries) {
-                    delay(50) // Wait before retry
-                }
-            }
-        }
+        searchFocusRequester.requestFocus()
     }
 
 
     Column(modifier = Modifier.fillMaxWidth()) {
-        // Use TextField with TextFieldValue for better cursor control
         TextField(
-            value = textFieldValue,
-            onValueChange = { newValue ->
-                textFieldValue = newValue
-                isUpdatingFromManager = true
-                try {
-                    manager.setClipboardSearchQuery(newValue.text)
-                } finally {
-                    isUpdatingFromManager = false
-                }
-            },
+            value = searchState.query,
+            onValueChange = { manager.setClipboardSearchQuery(it) },
             singleLine = true,
-            label = { Text(stringResource(R.string.search_clipboard_history_label)) },
+            placeholder = { Text("Search clipboard...") },
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(8.dp)
-                .focusRequester(focusRequester)
-                .onFocusChanged { focusState ->
-                    Log.d("ClipboardSearch", "SearchField onFocusChanged: focusState.isFocused=${focusState.isFocused}. Current manager.isClipboardSearchFocused: ${manager.isClipboardSearchFocusedState().value}")
-                    
-                    // Only update the manager's state if there's a real change
-                    val currentManagerState = manager.isClipboardSearchFocusedState().value
-                    if (focusState.isFocused && !currentManagerState) {
-                        Log.d("ClipboardSearch", "SearchField GAINED FOCUS: Updating manager state")
-                        manager.setClipboardSearchFocus(true)
-                    } else if (!focusState.isFocused && currentManagerState) {
-                        // Before updating the manager, check if this is a temporary focus loss
-                        Log.d("ClipboardSearch", "SearchField LOST FOCUS: Checking if we should update manager state")
-                        
-                        // Only update the manager if this isn't part of a focus change we're handling
-                        view.postDelayed({
-                            val focusedView = view.findFocus()
-                            val hasFocus = focusedView?.hasFocus() ?: false
-                            if (!hasFocus) {
-                                Log.d("ClipboardSearch", "Confirming focus loss, updating manager state")
-                                manager.setClipboardSearchFocus(false)
-                            } else {
-                                Log.d("ClipboardSearch", "Focus was restored, not updating manager state")
-                            }
-                        }, 100) // Small delay to allow focus to stabilize
-                    }
-                }
+                .focusRequester(searchFocusRequester)
+                .onFocusChanged { manager.setClipboardSearchFocus(it.isFocused) }
+            ,
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+            keyboardActions = KeyboardActions(onSearch = { manager.setClipboardSearchFocus(false) })
         )
 
         // Removed the LaunchedEffect keyed on requestSearchFocusState as it was ineffective.


### PR DESCRIPTION
## Summary
- simplify clipboard search state by introducing `ClipboardSearchState`
- manage search focus and cursor restoration via `clipboardSearchState`
- update UI rendering to check unified search state
- simplify clipboard history composable search field

## Testing
- `./gradlew assembleRelease` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68791c78c1ec8327920a8ba2029de2fd