### PR TITLE
Improve clipboard search focus handling

### DIFF
--- a/java/src/org/futo/inputmethod/latin/uix/ActionTextEdit.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/ActionTextEdit.kt
@@ -71,7 +71,8 @@ fun ActionTextEditor(
     multiline: Boolean = false,
     textSize: TextUnit = 16.sp,
     typeface: Typeface? = null,
-    autocorrect: Boolean = false
+    autocorrect: Boolean = false,
+    hint: String? = null
 ) {
     val context = LocalContext.current
     val manager = if(LocalInspectionMode.current) {
@@ -105,6 +106,7 @@ fun ActionTextEditor(
                 setTextChangeCallback { text.value = it }
 
                 setText(text.value)
+                hint?.let { setHint(it) }
                 setTextColor(color.toArgb())
 
                 setTextSize(TypedValue.COMPLEX_UNIT_PX, textSizeToUse)

--- a/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryComposables.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryComposables.kt
@@ -32,11 +32,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -262,105 +258,37 @@ fun ClipboardHistoryWindowContent(
     val view = LocalView.current
     val context = LocalContext.current
     val clipboardHistoryEnabledState = useDataStore(ClipboardHistoryEnabled, blocking = true)
-    val focusRequester = remember { FocusRequester() }
-    // val localFocusManager = LocalFocusManager.current // Not strictly needed if we change focus logic
+    val searchText = remember { mutableStateOf(manager.getClipboardSearchQuery()) }
 
-
-    // Use TextFieldValue to manage cursor position
-    var textFieldValue by remember {
-        mutableStateOf(TextFieldValue(manager.getClipboardSearchQuery()))
+    LaunchedEffect(searchText.value) {
+        manager.setClipboardSearchQuery(searchText.value)
     }
-    
-    // Track if we're currently updating from the manager to prevent loops
-    var isUpdatingFromManager by remember { mutableStateOf(false) }
-    
-    // Sync with manager's state
+
     LaunchedEffect(manager.getClipboardSearchQuery()) {
-        if (!isUpdatingFromManager) {
-            val currentText = textFieldValue.text
-            val managerText = manager.getClipboardSearchQuery()
-            
-            if (currentText != managerText) {
-                // Update the text and move cursor to the end
-                textFieldValue = TextFieldValue(
-                    text = managerText,
-                    selection = androidx.compose.ui.text.TextRange(managerText.length)
-                )
-            }
+        val managerText = manager.getClipboardSearchQuery()
+        if (managerText != searchText.value) {
+            searchText.value = managerText
         }
     }
-    
-    // Focus management effect - only run when the component is first composed or when explicitly requested
+
     LaunchedEffect(Unit) {
-        Log.d("ClipboardSearch", "Initial focus setup")
-        // Initial focus request with retry logic
-        var retryCount = 0
-        val maxRetries = 3
-        
-        while (retryCount < maxRetries) {
-            try {
-                focusRequester.requestFocus()
-                Log.d("ClipboardSearch", "Successfully requested focus (attempt ${retryCount + 1})")
-                break
-            } catch (e: IllegalStateException) {
-                Log.e("ClipboardSearch", "Failed to request focus (attempt ${retryCount + 1}): ${e.message}")
-                retryCount++
-                if (retryCount < maxRetries) {
-                    delay(50) // Wait before retry
-                }
-            }
-        }
+        manager.setClipboardSearchFocus(true)
     }
 
 
     Column(modifier = Modifier.fillMaxWidth()) {
-        // Use TextField with TextFieldValue for better cursor control
-        TextField(
-            value = textFieldValue,
-            onValueChange = { newValue ->
-                textFieldValue = newValue
-                isUpdatingFromManager = true
-                try {
-                    manager.setClipboardSearchQuery(newValue.text)
-                } finally {
-                    isUpdatingFromManager = false
-                }
-            },
-            singleLine = true,
-            label = { Text(stringResource(R.string.search_clipboard_history_label)) },
+        Box(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(8.dp)
-                .focusRequester(focusRequester)
-                .onFocusChanged { focusState ->
-                    Log.d("ClipboardSearch", "SearchField onFocusChanged: focusState.isFocused=${focusState.isFocused}. Current manager.isClipboardSearchFocused: ${manager.isClipboardSearchFocusedState().value}")
-                    
-                    // Only update the manager's state if there's a real change
-                    val currentManagerState = manager.isClipboardSearchFocusedState().value
-                    if (focusState.isFocused && !currentManagerState) {
-                        Log.d("ClipboardSearch", "SearchField GAINED FOCUS: Updating manager state")
-                        manager.setClipboardSearchFocus(true)
-                    } else if (!focusState.isFocused && currentManagerState) {
-                        // Before updating the manager, check if this is a temporary focus loss
-                        Log.d("ClipboardSearch", "SearchField LOST FOCUS: Checking if we should update manager state")
-                        
-                        // Only update the manager if this isn't part of a focus change we're handling
-                        view.postDelayed({
-                            val focusedView = view.findFocus()
-                            val hasFocus = focusedView?.hasFocus() ?: false
-                            if (!hasFocus) {
-                                Log.d("ClipboardSearch", "Confirming focus loss, updating manager state")
-                                manager.setClipboardSearchFocus(false)
-                            } else {
-                                Log.d("ClipboardSearch", "Focus was restored, not updating manager state")
-                            }
-                        }, 100) // Small delay to allow focus to stabilize
-                    }
-                }
-        )
+        ) {
+            ActionTextEditor(
+                text = searchText,
+                hint = stringResource(R.string.search_clipboard_history_label)
+            )
+        }
 
-        // Removed the LaunchedEffect keyed on requestSearchFocusState as it was ineffective.
-        // The focus request is now more direct in onFocusChanged.
+        // ActionTextEditor handles focus by overriding the input connection.
 
         // Keep this for general composition logging
         LaunchedEffect(Unit) {


### PR DESCRIPTION
## Summary
- expose a hint parameter for `ActionTextEditor`
- switch clipboard search bar to use `ActionTextEditor`
- remove unused focus handling logic

## Testing
- `./gradlew tasks --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ce20f64dc83278513a3918b2a66ca