### PR TITLE
Add setup skip option and restart entry

### DIFF
--- a/java/res/values/strings-uix.xml
+++ b/java/res/values/strings-uix.xml
@@ -620,6 +620,9 @@
     <string name="help_menu_email_subtitle">Private feedback, help, or don\'t use GitHub? Email us</string>
     <string name="help_menu_email_tags">gmail, support, contact, help, broken, bug, error, issue, problem, complaint, ticket, payment, support, glitch, malfunction, fix, customer service, crash, question, inquiry, assistance</string>
 
+    <string name="settings_rerun_setup_title">Run setup again</string>
+    <string name="settings_rerun_setup_subtitle">Restart the guided setup to review permissions and backups</string>
+
     <!-- Setup configuration -->
     <string name="setup_step_1">Setup - Step 1</string>
     <string name="setup_step_2">Setup - Step 2</string>
@@ -630,9 +633,10 @@
     <string name="setup_active_input_method">Please select FUTO Keyboard as your active input method.</string>
     <string name="setup_switch_input_methods">Switch Input Methods</string>
 
-    <string name="setup_permissions_text">Enable accessibility service to allow app switching</string>
+    <string name="setup_permissions_text">Enable accessibility service to allow app switching. You can skip this step now and enable it later from Settings.</string>
     <string name="setup_permissions_granted_text">Accessibility service is enabled! You can now switch between apps.</string>
     <string name="setup_grant_permissions_button">Grant Permission</string>
+    <string name="setup_skip_for_now_button">Skip for now</string>
     <string name="setup_continue_button">Continue</string>
 
     <string name="setup_step_restore_backup">Step 3: Restore Backup (Optional)</string>

--- a/java/src/org/futo/inputmethod/latin/uix/settings/SettingsActivity.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/SettingsActivity.kt
@@ -43,6 +43,8 @@ import org.futo.inputmethod.latin.uix.IMPORT_SETTINGS_REQUEST
 import org.futo.inputmethod.latin.uix.ImportResourceActivity
 import org.futo.inputmethod.latin.uix.SettingsExporter
 import org.futo.inputmethod.latin.uix.THEME_KEY
+import org.futo.inputmethod.latin.uix.IS_SETUP_COMPLETE
+import org.futo.inputmethod.latin.uix.dataStore
 import org.futo.inputmethod.latin.uix.getSettingBlocking
 import org.futo.inputmethod.latin.uix.getSettingFlow
 import org.futo.inputmethod.latin.uix.theme.ThemeOption
@@ -93,6 +95,7 @@ class SettingsActivity : ComponentActivity(), DynamicThemeProviderOwner {
     private val inputMethodEnabled = mutableStateOf(false)
     private val inputMethodSelected = mutableStateOf(false)
     private val doublePackage = mutableStateOf(false)
+    private val setupRestartCounter = mutableStateOf(0)
 
     private var wasImeEverDisabled = false
 
@@ -153,6 +156,19 @@ class SettingsActivity : ComponentActivity(), DynamicThemeProviderOwner {
         navigatorProvider.addNavigator(DialogNavigator())
     }
 
+    fun restartSetupFromSettings() {
+        lifecycleScope.launch {
+            applicationContext.dataStore.updateData { preferences ->
+                preferences.toMutablePreferences().apply {
+                    this[IS_SETUP_COMPLETE] = false
+                }
+            }
+            setupRestartCounter.value = setupRestartCounter.value + 1
+        }
+
+        navController.popBackStack("home", inclusive = false)
+    }
+
     private fun updateContent() {
         setContent {
             DataStoreCacheProvider {
@@ -165,13 +181,14 @@ class SettingsActivity : ComponentActivity(), DynamicThemeProviderOwner {
                         ) {
                             Box(Modifier.safeDrawingPadding()) {
                                 // Calling SetupNavigation from Setup.kt
-                                SetupNavigation(
-                                    imeEnabled = inputMethodEnabled.value,
-                                    imeSelected = inputMethodSelected.value,
-                                    doublePackage = doublePackage.value
-                                ) {
-                                    SettingsNavigator(navController = navController)
-                                }
+                            SetupNavigation(
+                                imeEnabled = inputMethodEnabled.value,
+                                imeSelected = inputMethodSelected.value,
+                                doublePackage = doublePackage.value,
+                                restartCounter = setupRestartCounter.value
+                            ) {
+                                SettingsNavigator(navController = navController)
+                            }
                             }
                         }
                     }

--- a/java/src/org/futo/inputmethod/latin/uix/settings/Setup.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/Setup.kt
@@ -182,6 +182,7 @@ fun SetupNavigation(
     imeEnabled: Boolean,
     imeSelected: Boolean,
     doublePackage: Boolean,
+    restartCounter: Int = 0,
     main: @Composable () -> Unit
 ) {
     val context = LocalContext.current
@@ -195,17 +196,31 @@ fun SetupNavigation(
     }
 
     var currentStep by remember { mutableStateOf(0) }
+    var isManualRestarting by remember { mutableStateOf(false) }
 
-    LaunchedEffect(isSetupComplete, imeEnabled, imeSelected) {
+    LaunchedEffect(restartCounter) {
+        if (restartCounter > 0) {
+            currentStep = 1
+            isManualRestarting = true
+        }
+    }
+
+    LaunchedEffect(isSetupComplete, imeEnabled, imeSelected, isManualRestarting) {
         isSetupComplete?.let {
-            currentStep = if (it) {
-                6 // Go directly to main settings
-            } else if (!imeEnabled) {
-                1
-            } else if (!imeSelected) {
-                2
+            if (isManualRestarting) {
+                if (currentStep >= 6) {
+                    isManualRestarting = false
+                }
             } else {
-                3
+                currentStep = if (it) {
+                    6 // Go directly to main settings
+                } else if (!imeEnabled) {
+                    1
+                } else if (!imeSelected) {
+                    2
+                } else {
+                    3
+                }
             }
         }
     }

--- a/java/src/org/futo/inputmethod/latin/uix/settings/SetupRequestPermissions.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/SetupRequestPermissions.kt
@@ -10,11 +10,10 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -112,6 +111,17 @@ fun SetupRequestPermissions(onFinished: () -> Unit = { }) {
                         stringResource(R.string.setup_grant_permissions_button)
                     }
                 )
+            }
+
+            if (!isPermissionGranted) {
+                Button(
+                    onClick = onFinished,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp)
+                ) {
+                    Text(stringResource(R.string.setup_skip_for_now_button))
+                }
             }
         }
     }

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/Home.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/Home.kt
@@ -44,6 +44,7 @@ import org.futo.inputmethod.latin.uix.TextEditPopupActivity
 import org.futo.inputmethod.latin.uix.USE_SYSTEM_VOICE_INPUT
 import org.futo.inputmethod.latin.uix.settings.NavigationItem
 import org.futo.inputmethod.latin.uix.settings.NavigationItemStyle
+import org.futo.inputmethod.latin.uix.settings.SettingsActivity
 import org.futo.inputmethod.latin.uix.settings.UserSetting
 import org.futo.inputmethod.latin.uix.settings.UserSettingsMenu
 import org.futo.inputmethod.latin.uix.settings.render
@@ -137,6 +138,21 @@ val HomeScreenLite = UserSettingsMenu(
             navigateTo = "help",
             icon = R.drawable.help_circle
         ),
+
+        UserSetting(
+            name = R.string.settings_rerun_setup_title
+        ) {
+            val navController = LocalNavController.current
+            NavigationItem(
+                title = stringResource(R.string.settings_rerun_setup_title),
+                subtitle = stringResource(R.string.settings_rerun_setup_subtitle),
+                style = NavigationItemStyle.Misc,
+                navigate = {
+                    (navController?.context as? SettingsActivity)?.restartSetupFromSettings()
+                },
+                icon = painterResource(R.drawable.settings)
+            )
+        },
 
         //if(isDeveloper || LocalInspectionMode.current) {
         userSettingNavigationItem(


### PR DESCRIPTION
## Summary
- allow skipping the accessibility permission step during setup with a dedicated button and updated guidance
- add a settings entry that restarts the guided setup flow from within the app and resets completion status
- handle setup restart logic to begin from the first step when manually triggered

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693cbfc32c7c8327b03500b93eebb42e)