### PR TITLE
Add session ID guard to audio recognizer callbacks

### DIFF
--- a/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/AudioRecognizer.kt
+++ b/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/AudioRecognizer.kt
@@ -47,6 +47,7 @@ import org.futo.voiceinput.shared.whisper.isBlankResult
 import org.futo.voiceinput.shared.util.normalizeTranscription
 import java.nio.FloatBuffer
 import java.nio.ShortBuffer
+import java.util.concurrent.atomic.AtomicLong
 import kotlin.math.min
 import kotlin.math.pow
 import kotlin.math.sqrt
@@ -106,7 +107,7 @@ class AudioRecognizer(
 ) {
     private var isRecording = false
     private var recorder: AudioRecord? = null
-    @Volatile private var sessionId: Long = 0
+    private val sessionId = AtomicLong(0)
 
     init {
         modelManager.useGpu = settings.useGpuOffload
@@ -226,7 +227,7 @@ class AudioRecognizer(
     }
 
     fun reset() {
-        sessionId++
+        sessionId.incrementAndGet()
         recorder?.stop()
         recorderJob?.cancel()
 
@@ -524,7 +525,7 @@ class AudioRecognizer(
     }
 
     private fun startRecording() {
-        sessionId++
+        val currentSessionId = sessionId.incrementAndGet()
         val device = try {
             createRecorderAndJob(settings.recordingConfiguration.preferBluetoothMic)
         } catch (e: SecurityException) {
@@ -544,6 +545,7 @@ class AudioRecognizer(
                     preloadModels()
                 } catch(_: InvalidModelException) {
                     withContext(Dispatchers.Main) {
+                        if (currentSessionId != sessionId.get()) return@withContext
                         reset()
                         listener.modelLoadingFailed()
                     }
@@ -553,19 +555,21 @@ class AudioRecognizer(
     }
 
     private suspend fun runModel() {
-        val currentSessionId = sessionId
+        val currentSessionId = sessionId.get()
 
         val runnerCallback: ModelInferenceCallback = object : ModelInferenceCallback {
             override fun updateStatus(state: InferenceState) {
+                if (currentSessionId != sessionId.get()) return
                 listener.decodingStatus(state)
             }
 
             override fun languageDetected(language: Language) {
+                if (currentSessionId != sessionId.get()) return
                 listener.languageDetected(language)
             }
 
             override fun partialResult(string: String) {
-                if (currentSessionId != sessionId) return
+                if (currentSessionId != sessionId.get()) return
                 if(isBlankResult(string)) return
                 listener.partialResult(normalizeTranscription(string))
             }
@@ -577,6 +581,8 @@ class AudioRecognizer(
                 it.join()
             }
         }
+
+        if (currentSessionId != sessionId.get()) return
 
         val floatArray = floatSamples.array().sliceArray(0 until floatSamples.position())
 
@@ -593,11 +599,11 @@ class AudioRecognizer(
                 
                 if (!groqResult.isNullOrBlank()) {
                     // Groq succeeded, return its result
-                    if (currentSessionId != sessionId) return
+                    if (currentSessionId != sessionId.get()) return
                     yield()
                     lifecycleScope.launch {
                         withContext(Dispatchers.Main) {
-                            if (currentSessionId != sessionId) return@withContext
+                            if (currentSessionId != sessionId.get()) return@withContext
                             listener.finished(normalizeTranscription(groqResult))
                         }
                     }
@@ -623,14 +629,14 @@ class AudioRecognizer(
             return
         }
 
-        if (currentSessionId != sessionId) return
+        if (currentSessionId != sessionId.get()) return
 
         val text = if (isBlankResult(outputText)) "" else outputText
 
         yield()
         lifecycleScope.launch {
             withContext(Dispatchers.Main) {
-                if (currentSessionId != sessionId) return@withContext
+                if (currentSessionId != sessionId.get()) return@withContext
                 yield()
                 listener.finished(normalizeTranscription(text))
             }

--- a/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/AudioRecognizer.kt
+++ b/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/AudioRecognizer.kt
@@ -106,6 +106,7 @@ class AudioRecognizer(
 ) {
     private var isRecording = false
     private var recorder: AudioRecord? = null
+    @Volatile private var sessionId: Long = 0
 
     init {
         modelManager.useGpu = settings.useGpuOffload
@@ -225,6 +226,7 @@ class AudioRecognizer(
     }
 
     fun reset() {
+        sessionId++
         recorder?.stop()
         recorderJob?.cancel()
 
@@ -522,6 +524,7 @@ class AudioRecognizer(
     }
 
     private fun startRecording() {
+        sessionId++
         val device = try {
             createRecorderAndJob(settings.recordingConfiguration.preferBluetoothMic)
         } catch (e: SecurityException) {
@@ -549,22 +552,25 @@ class AudioRecognizer(
         }
     }
 
-    private val runnerCallback: ModelInferenceCallback = object : ModelInferenceCallback {
-        override fun updateStatus(state: InferenceState) {
-            listener.decodingStatus(state)
-        }
-
-        override fun languageDetected(language: Language) {
-            listener.languageDetected(language)
-        }
-
-        override fun partialResult(string: String) {
-            if(isBlankResult(string)) return
-            listener.partialResult(normalizeTranscription(string))
-        }
-    }
-
     private suspend fun runModel() {
+        val currentSessionId = sessionId
+
+        val runnerCallback: ModelInferenceCallback = object : ModelInferenceCallback {
+            override fun updateStatus(state: InferenceState) {
+                listener.decodingStatus(state)
+            }
+
+            override fun languageDetected(language: Language) {
+                listener.languageDetected(language)
+            }
+
+            override fun partialResult(string: String) {
+                if (currentSessionId != sessionId) return
+                if(isBlankResult(string)) return
+                listener.partialResult(normalizeTranscription(string))
+            }
+        }
+
         loadModelJob?.let {
             if (it.isActive) {
                 println("Model was not finished loading...")
@@ -587,9 +593,11 @@ class AudioRecognizer(
                 
                 if (!groqResult.isNullOrBlank()) {
                     // Groq succeeded, return its result
+                    if (currentSessionId != sessionId) return
                     yield()
                     lifecycleScope.launch {
                         withContext(Dispatchers.Main) {
+                            if (currentSessionId != sessionId) return@withContext
                             listener.finished(normalizeTranscription(groqResult))
                         }
                     }
@@ -615,11 +623,14 @@ class AudioRecognizer(
             return
         }
 
+        if (currentSessionId != sessionId) return
+
         val text = if (isBlankResult(outputText)) "" else outputText
 
         yield()
         lifecycleScope.launch {
             withContext(Dispatchers.Main) {
+                if (currentSessionId != sessionId) return@withContext
                 yield()
                 listener.finished(normalizeTranscription(text))
             }


### PR DESCRIPTION
## Summary
- add a session id counter to AudioRecognizer and increment it on resets and recording starts
- guard partial and finished callbacks against stale session ids so late callbacks are ignored

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693cc44304a483278e4ea106d1350196)