### PR TITLE
Improve selection gesture persistence and velocity

### DIFF
--- a/docs/productivity-improvements.md
+++ b/docs/productivity-improvements.md
@@ -1,0 +1,19 @@
+# Productivity Improvements Overview
+
+This document outlines ideas to streamline text entry and navigation in the keyboard, with special emphasis on cursor control and selection workflows.
+
+## Power-User Cursor and Selection Controls
+- **Two-finger drag to select**: Treat a second finger drag as a selection gesture, selecting the range between the initial cursor position and the drag end point.
+- **Double-drag word/line selection**: Interpret a rapid second drag after a placement drag as a request to expand to the nearest word boundary or entire line.
+- **Sticky selection modifiers**: Allow a long-press on Shift or a dedicated selection toggle to keep selection mode active while moving the cursor with drag or arrow gestures.
+- **Precision vs. velocity mode**: Switch between pixel-precise movement and accelerated movement based on drag distance or pressure, improving navigation in long documents.
+- **Haptic/visual feedback**: Provide subtle haptics and highlight updates when selection begins, expands, or snaps to word/line boundaries to reinforce state changes.
+
+## Other Productivity Features to Explore
+- **Clipboard search completion**: Finish the in-clipboard search integration described in `PLAN.md`, wiring focus state, showing the keyboard under the clipboard window, and routing keystrokes into the search field.
+- **Quick Switch enhancements**: Expand the existing Quick Switch to optionally keep a short history (3–5 apps) with configurable shortcuts for rapid app hopping.
+- **AI-assisted templates**: Extend AI Reply and "AI Generate" clipboard actions with reusable templates and macros for common responses while keeping offline defaults safe.
+- **Voice input shortcuts**: Add toggles for auto-punctuation and commands like "newline" or "undo" to speed hands-free entry without losing control.
+- **Editable gesture map**: Offer a settings page for customizing gesture bindings (e.g., selecting words, lines, or paragraphs) to fit different user preferences.
+
+These ideas can be iterated independently and combined to deliver a faster, more controllable typing experience for advanced users.

--- a/java/src/org/futo/inputmethod/engine/CursorSelectionGranularity.java
+++ b/java/src/org/futo/inputmethod/engine/CursorSelectionGranularity.java
@@ -1,0 +1,7 @@
+package org.futo.inputmethod.engine;
+
+public enum CursorSelectionGranularity {
+    CHARACTER,
+    WORD,
+    LINE
+}

--- a/java/src/org/futo/inputmethod/engine/IMEInterface.kt
+++ b/java/src/org/futo/inputmethod/engine/IMEInterface.kt
@@ -1,6 +1,7 @@
 package org.futo.inputmethod.engine
 
 import org.futo.inputmethod.annotations.UsedForTesting
+import org.futo.inputmethod.engine.CursorSelectionGranularity
 import org.futo.inputmethod.event.Event
 import org.futo.inputmethod.latin.common.Constants
 import org.futo.inputmethod.latin.common.InputPointers
@@ -71,6 +72,7 @@ interface IMEInterface {
     fun onUpWithPointerActive()
     fun onSwipeLanguage(direction: Int)
     fun onMovingCursorLockEvent(canMoveCursor: Boolean)
+    fun onSelectionUpdate(selecting: Boolean, granularity: CursorSelectionGranularity, sticky: Boolean, precisionMode: Boolean)
     fun clearUserHistoryDictionaries()
 
     /** Refresh as a result of blacklist update */

--- a/java/src/org/futo/inputmethod/engine/general/ActionInputTransactionIME.kt
+++ b/java/src/org/futo/inputmethod/engine/general/ActionInputTransactionIME.kt
@@ -2,6 +2,7 @@ package org.futo.inputmethod.engine.general
 
 import org.futo.inputmethod.engine.IMEHelper
 import org.futo.inputmethod.engine.IMEInterface
+import org.futo.inputmethod.engine.CursorSelectionGranularity
 import org.futo.inputmethod.event.Event
 import org.futo.inputmethod.latin.InputConnectionInternalComposingWrapper
 import org.futo.inputmethod.latin.SupportsNonComposing
@@ -60,6 +61,7 @@ class ActionInputTransactionIME(val helper: IMEHelper) : IMEInterface, ActionInp
     override fun onUpWithPointerActive() {}
     override fun onSwipeLanguage(direction: Int) {}
     override fun onMovingCursorLockEvent(canMoveCursor: Boolean) {}
+    override fun onSelectionUpdate(selecting: Boolean, granularity: CursorSelectionGranularity, sticky: Boolean, precisionMode: Boolean) {}
     override fun clearUserHistoryDictionaries() {}
     override fun requestSuggestionRefresh() {}
     override fun onLayoutUpdated(layout: KeyboardLayoutSetV2) { }

--- a/java/src/org/futo/inputmethod/engine/general/GeneralIME.kt
+++ b/java/src/org/futo/inputmethod/engine/general/GeneralIME.kt
@@ -13,6 +13,7 @@ import org.futo.inputmethod.engine.GlobalIMEMessage
 import org.futo.inputmethod.engine.IMEHelper
 import org.futo.inputmethod.engine.IMEInterface
 import org.futo.inputmethod.engine.IMEMessage
+import org.futo.inputmethod.engine.CursorSelectionGranularity
 import org.futo.inputmethod.event.Event
 import org.futo.inputmethod.event.InputTransaction
 import org.futo.inputmethod.keyboard.KeyboardSwitcher
@@ -109,6 +110,11 @@ class GeneralIME(val helper: IMEHelper) : IMEInterface, WordLearner, SuggestionS
         suggestionBlacklist = suggestionBlacklist,
         suggestedWordsCallback = this
     )
+
+    private var selectionActive: Boolean = false
+    private var selectionGranularity: CursorSelectionGranularity = CursorSelectionGranularity.CHARACTER
+    private var selectionSticky: Boolean = false
+    private var precisionCursorMode: Boolean = true
 
     override fun addToHistory(
         word: String,
@@ -486,32 +492,37 @@ class GeneralIME(val helper: IMEHelper) : IMEInterface, WordLearner, SuggestionS
         setNeutralSuggestionStrip()
 
         val shiftMode: Int = helper.keyboardShiftMode
-        val select = select
+        var shouldSelect = select
             ?: ((shiftMode == WordComposer.CAPS_MODE_MANUAL_SHIFTED) || (shiftMode == WordComposer.CAPS_MODE_MANUAL_SHIFT_LOCKED))
+        shouldSelect = shouldSelect || selectionActive
+        val shouldStepOverWords = stepOverWords || selectionGranularity == CursorSelectionGranularity.WORD
+        val effectiveSteps = if (precisionCursorMode) steps else steps * 3
 
-        if (select) {
+        if (shouldSelect) {
             inputLogic.disableRecapitalization()
         }
 
-        if (steps < 0) {
-            inputLogic.cursorLeft(steps, stepOverWords, select)
+        if (effectiveSteps < 0) {
+            inputLogic.cursorLeft(effectiveSteps, shouldStepOverWords, shouldSelect)
         } else {
-            inputLogic.cursorRight(steps, stepOverWords, select)
+            inputLogic.cursorRight(effectiveSteps, shouldStepOverWords, shouldSelect)
         }
     }
 
     override fun onMoveDeletePointer(steps: Int) {
         setNeutralSuggestionStrip()
+        val effectiveSteps = if (precisionCursorMode) steps else steps * 3
         if (inputLogic.mConnection.hasCursorPosition()) {
             val stepOverWords =
                 settings.current.mBackspaceMode == Settings.BACKSPACE_MODE_WORDS
-            if (steps < 0) {
-                inputLogic.cursorLeft(steps, stepOverWords, true)
+            val shouldSelect = selectionActive
+            if (effectiveSteps < 0) {
+                inputLogic.cursorLeft(effectiveSteps, stepOverWords, true || shouldSelect)
             } else {
-                inputLogic.cursorRight(steps, stepOverWords, true)
+                inputLogic.cursorRight(effectiveSteps, stepOverWords, true || shouldSelect)
             }
         } else {
-            var steps = steps
+            var steps = effectiveSteps
             while (steps < 0) {
                 onEvent(
                     Event.createSoftwareKeypressEvent(
@@ -587,6 +598,27 @@ class GeneralIME(val helper: IMEHelper) : IMEInterface, WordLearner, SuggestionS
 
     override fun onMovingCursorLockEvent(canMoveCursor: Boolean) {
         // GeneralIME does nothing
+    }
+
+    override fun onSelectionUpdate(
+        selecting: Boolean,
+        granularity: CursorSelectionGranularity,
+        sticky: Boolean,
+        precisionMode: Boolean
+    ) {
+        selectionGranularity = granularity
+        selectionSticky = when {
+            sticky -> true
+            !selecting -> false
+            else -> selectionSticky
+        }
+        selectionActive = selecting || selectionSticky
+        precisionCursorMode = precisionMode
+
+        if (!selectionActive && !selectionSticky) {
+            selectionGranularity = CursorSelectionGranularity.CHARACTER
+            precisionCursorMode = true
+        }
     }
 
     override fun clearUserHistoryDictionaries() {

--- a/java/src/org/futo/inputmethod/engine/general/JapaneseIME.kt
+++ b/java/src/org/futo/inputmethod/engine/general/JapaneseIME.kt
@@ -26,6 +26,7 @@ import org.futo.inputmethod.engine.GlobalIMEMessage
 import org.futo.inputmethod.engine.IMEHelper
 import org.futo.inputmethod.engine.IMEInterface
 import org.futo.inputmethod.engine.IMEMessage
+import org.futo.inputmethod.engine.CursorSelectionGranularity
 import org.futo.inputmethod.event.Event
 import org.futo.inputmethod.keyboard.KeyboardId
 import org.futo.inputmethod.keyboard.internal.KeyboardLayoutKind
@@ -1185,6 +1186,15 @@ class JapaneseIME(val helper: IMEHelper) : IMEInterface {
     }
 
     override fun onMovingCursorLockEvent(canMoveCursor: Boolean) {
+
+    }
+
+    override fun onSelectionUpdate(
+        selecting: Boolean,
+        granularity: CursorSelectionGranularity,
+        sticky: Boolean,
+        precisionMode: Boolean
+    ) {
 
     }
 

--- a/java/src/org/futo/inputmethod/keyboard/KeyboardActionListener.java
+++ b/java/src/org/futo/inputmethod/keyboard/KeyboardActionListener.java
@@ -18,6 +18,7 @@ package org.futo.inputmethod.keyboard;
 
 import org.futo.inputmethod.latin.common.Constants;
 import org.futo.inputmethod.latin.common.InputPointers;
+import org.futo.inputmethod.engine.CursorSelectionGranularity;
 
 public interface KeyboardActionListener {
     /**
@@ -108,6 +109,8 @@ public interface KeyboardActionListener {
     public void onUpWithPointerActive();
     public void onSwipeLanguage(int direction);
     public void onMovingCursorLockEvent(boolean canMoveCursor);
+    public void onSelectionUpdate(boolean selecting, CursorSelectionGranularity granularity,
+                                  boolean sticky, boolean precisionMode);
 
     public static final KeyboardActionListener EMPTY_LISTENER = new Adapter();
 
@@ -148,5 +151,9 @@ public interface KeyboardActionListener {
         public void onSwipeLanguage(int direction) {}
         @Override
         public void onMovingCursorLockEvent(boolean canMoveCursor) {}
+
+        @Override
+        public void onSelectionUpdate(boolean selecting, CursorSelectionGranularity granularity,
+                                      boolean sticky, boolean precisionMode) {}
     }
 }

--- a/java/src/org/futo/inputmethod/keyboard/PointerTracker.java
+++ b/java/src/org/futo/inputmethod/keyboard/PointerTracker.java
@@ -22,6 +22,7 @@ import android.os.SystemClock;
 import android.util.Log;
 import android.view.MotionEvent;
 
+import org.futo.inputmethod.engine.CursorSelectionGranularity;
 import org.futo.inputmethod.keyboard.internal.BatchInputArbiter;
 import org.futo.inputmethod.keyboard.internal.BatchInputArbiter.BatchInputArbiterListener;
 import org.futo.inputmethod.keyboard.internal.BogusMoveEventDetector;
@@ -94,6 +95,8 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
             (int)(128.0 * Resources.getSystem().getDisplayMetrics().density),
             Resources.getSystem().getDisplayMetrics().widthPixels * 3 / 2
     );
+    private static final long SELECTION_DOUBLE_DRAG_TIMEOUT_MS = 450;
+    private static long sLastCursorDragEndTime = 0;
 
     private static GestureStrokeRecognitionParams sGestureStrokeRecognitionParams;
     private static GestureStrokeDrawingParams sGestureStrokeDrawingParams;
@@ -150,6 +153,9 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
     private boolean mStartedOnFastLongPress;
     private boolean mCursorMoved = false;
     private boolean mSpacebarLongPressed = false;
+    private boolean mSelectionStickyRequested = false;
+    private boolean mSelectionGestureActive = false;
+    private CursorSelectionGranularity mSelectionGranularity = CursorSelectionGranularity.CHARACTER;
 
     // true if keyboard layout has been changed.
     private boolean mKeyboardLayoutHasBeenChanged;
@@ -750,6 +756,8 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
             mIsFlickingKey = !mIsSlidingCursor && key.getHasFlick();
             mFlickDirection = key.flickDirection(0, 0);
             mCurrentKey = key;
+            mSelectionStickyRequested = false;
+            mSelectionGranularity = CursorSelectionGranularity.CHARACTER;
         }
     }
 
@@ -763,6 +771,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
     private void resetKeySelectionByDraggingFinger() {
         mIsInDraggingFinger = false;
         mIsInSlidingKeyInput = false;
+        mSelectionGestureActive = false;
         sDrawingProxy.showSlidingKeyInputPreview(null /* tracker */);
     }
 
@@ -962,6 +971,17 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
 
             int steps = (x - mStartX) / pointerStep;
             int vsteps = (y - mStartY) / pointerStep;
+            final boolean multiTouchSelecting = getActivePointerTrackerCount() > 1;
+            final boolean doubleDragSelecting = SystemClock.uptimeMillis() - sLastCursorDragEndTime < SELECTION_DOUBLE_DRAG_TIMEOUT_MS;
+            mSelectionGestureActive = mSelectionGestureActive || multiTouchSelecting || doubleDragSelecting;
+            final boolean selecting = multiTouchSelecting || doubleDragSelecting || mSelectionGestureActive;
+            mSelectionGranularity = Math.abs(vsteps) > Math.abs(steps)
+                    ? CursorSelectionGranularity.LINE
+                    : (selecting || Math.abs(steps) > 1 ? CursorSelectionGranularity.WORD : CursorSelectionGranularity.CHARACTER);
+            final boolean precisionMode = Math.abs(x - mStartX) < sPointerBigStep && Math.abs(y - mStartY) < sPointerBigStep;
+            if (!precisionMode) {
+                pointerStep = Math.max(1, pointerStep / 2);
+            }
             final int swipeIgnoreTime = settingsValues.mKeyLongpressTimeout / MULTIPLIER_FOR_LONG_PRESS_TIMEOUT_IN_SLIDING_INPUT;
             if (steps != 0 && mStartTime + swipeIgnoreTime < System.currentTimeMillis()) {
                 mCursorMoved = true;
@@ -970,14 +990,18 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
                 if(settingsValues.mSpacebarMode == Settings.SPACEBAR_MODE_SWIPE_LANGUAGE && !mSpacebarLongPressed) {
                     sListener.onSwipeLanguage(steps);
                 } else {
+                    sListener.onSelectionUpdate(selecting, mSelectionGranularity, multiTouchSelecting, precisionMode);
                     sListener.onMovePointer(steps);
+                    mSelectionStickyRequested = mSelectionStickyRequested || multiTouchSelecting || mSelectionGestureActive;
                 }
             }
 
             if (vsteps != 0 && mStartTime + swipeIgnoreTime < System.currentTimeMillis()) {
                 mCursorMoved = true;
                 mStartY += vsteps * pointerStep;
+                sListener.onSelectionUpdate(selecting, mSelectionGranularity, multiTouchSelecting, precisionMode);
                 sListener.onMovePointerVertical(vsteps);
+                mSelectionStickyRequested = mSelectionStickyRequested || multiTouchSelecting || mSelectionGestureActive;
             }
 
             mLastX = x;
@@ -992,6 +1016,15 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
             }
 
             int steps = (x - mStartX) / pointerStep;
+            final boolean multiTouchSelecting = getActivePointerTrackerCount() > 1;
+            final boolean doubleDragSelecting = SystemClock.uptimeMillis() - sLastCursorDragEndTime < SELECTION_DOUBLE_DRAG_TIMEOUT_MS;
+            mSelectionGestureActive = mSelectionGestureActive || multiTouchSelecting || doubleDragSelecting;
+            final boolean selecting = multiTouchSelecting || doubleDragSelecting || mSelectionGestureActive;
+            mSelectionGranularity = CursorSelectionGranularity.WORD;
+            final boolean precisionMode = Math.abs(x - mStartX) < sPointerBigStep;
+            if (!precisionMode) {
+                pointerStep = Math.max(1, pointerStep / 2);
+            }
             if (steps != 0) {
                 sTimerProxy.cancelKeyTimersOf(this);
                 mCursorMoved = true;
@@ -999,6 +1032,10 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
 
                 if(settingsValues.mIsRTL) steps = -steps;
 
+                if (selecting) {
+                    sListener.onSelectionUpdate(true, mSelectionGranularity, multiTouchSelecting, precisionMode);
+                    mSelectionStickyRequested = mSelectionStickyRequested || multiTouchSelecting || mSelectionGestureActive;
+                }
                 sListener.onMoveDeletePointer(steps);
             }
 
@@ -1110,6 +1147,16 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
         // Sliding cursor / delete gestures are finished; hide any cursor overlays
         if (mCursorMoved) {
             sListener.onMovingCursorLockEvent(false);
+            if (isInSlidingKeyInput) {
+                sLastCursorDragEndTime = eventTime;
+                mSelectionStickyRequested = mSelectionStickyRequested || mSelectionGestureActive;
+                if (!mSelectionStickyRequested) {
+                    sListener.onSelectionUpdate(false, CursorSelectionGranularity.CHARACTER, false, true);
+                } else {
+                    sListener.onSelectionUpdate(true, mSelectionGranularity, true, true);
+                }
+                mSelectionStickyRequested = false;
+            }
         }
 
         if(mIsFlickingKey && currentKey != null) {

--- a/java/src/org/futo/inputmethod/latin/LatinIMELegacy.java
+++ b/java/src/org/futo/inputmethod/latin/LatinIMELegacy.java
@@ -57,6 +57,7 @@ import org.futo.inputmethod.accessibility.AccessibilityUtils;
 import org.futo.inputmethod.annotations.UsedForTesting;
 import org.futo.inputmethod.compat.ViewOutlineProviderCompatUtils;
 import org.futo.inputmethod.compat.ViewOutlineProviderCompatUtils.InsetsUpdater;
+import org.futo.inputmethod.engine.CursorSelectionGranularity;
 import org.futo.inputmethod.engine.IMEInterface;
 import org.futo.inputmethod.engine.IMEManager;
 import org.futo.inputmethod.event.Event;
@@ -135,6 +136,11 @@ public class LatinIMELegacy implements KeyboardActionListener,
     private RichInputMethodManager mRichImm;
     public final KeyboardSwitcher mKeyboardSwitcher;
     private EmojiAltPhysicalKeyDetector mEmojiAltPhysicalKeyDetector;
+
+    private boolean mSelectionActive = false;
+    private CursorSelectionGranularity mSelectionGranularity = CursorSelectionGranularity.CHARACTER;
+    private boolean mStickySelection = false;
+    private boolean mPrecisionCursorMode = true;
 
     // Used for re-initialize keyboard layout after onConfigurationChange.
     @Nullable private Context mDisplayContext;
@@ -618,9 +624,11 @@ public class LatinIMELegacy implements KeyboardActionListener,
 
     @Override
     public void onMovePointer(int steps) {
+        final int effectiveSteps = mPrecisionCursorMode ? steps : steps * 3;
+        final boolean stepOverWords = mSelectionGranularity == CursorSelectionGranularity.WORD;
         mImeManager.getActiveIME(
                 mSettings.getCurrent()
-        ).onMovePointer(steps, false, null);
+        ).onMovePointer(effectiveSteps, stepOverWords, mSelectionActive);
     }
 
     @Override
@@ -629,13 +637,15 @@ public class LatinIMELegacy implements KeyboardActionListener,
 
         final InputConnection ic = mInputMethodService.getCurrentInputConnection();
         if (ic == null) return;
-        
+
         ic.beginBatchEdit();
-        final int keyCode = steps < 0 ? KeyEvent.KEYCODE_DPAD_UP : KeyEvent.KEYCODE_DPAD_DOWN;
+        final int effectiveSteps = mPrecisionCursorMode ? steps : steps * 2;
+        final int keyCode = effectiveSteps < 0 ? KeyEvent.KEYCODE_DPAD_UP : KeyEvent.KEYCODE_DPAD_DOWN;
+        final int metaState = mSelectionActive ? KeyEvent.META_SHIFT_ON : 0;
         final long eventTime = android.os.SystemClock.uptimeMillis();
-        for(int i = 0; i < Math.abs(steps); i++) {
-            ic.sendKeyEvent(new KeyEvent(eventTime, eventTime, KeyEvent.ACTION_DOWN, keyCode, 0));
-            ic.sendKeyEvent(new KeyEvent(eventTime, eventTime, KeyEvent.ACTION_UP, keyCode, 0));
+        for(int i = 0; i < Math.abs(effectiveSteps); i++) {
+            ic.sendKeyEvent(new KeyEvent(eventTime, eventTime, KeyEvent.ACTION_DOWN, keyCode, 0, metaState));
+            ic.sendKeyEvent(new KeyEvent(eventTime, eventTime, KeyEvent.ACTION_UP, keyCode, 0, metaState));
         }
         ic.endBatchEdit();
     }
@@ -678,6 +688,28 @@ public class LatinIMELegacy implements KeyboardActionListener,
                 ((InputView)mInputView).showCursorOverlays(false);
             }
         }
+    }
+
+    @Override
+    public void onSelectionUpdate(boolean selecting, CursorSelectionGranularity granularity, boolean sticky, boolean precisionMode) {
+        mSelectionGranularity = granularity;
+        mPrecisionCursorMode = precisionMode;
+        if (sticky) {
+            mStickySelection = true;
+        } else if (!selecting) {
+            mStickySelection = false;
+        }
+
+        mSelectionActive = selecting || mStickySelection;
+
+        if (!mSelectionActive && !mStickySelection) {
+            mSelectionGranularity = CursorSelectionGranularity.CHARACTER;
+            mPrecisionCursorMode = true;
+        }
+
+        mImeManager.getActiveIME(
+                mSettings.getCurrent()
+        ).onSelectionUpdate(mSelectionActive, mSelectionGranularity, mStickySelection, mPrecisionCursorMode);
     }
 
     // TODO: Instead of checking for alphabetic keyboard here, separate keycodes for


### PR DESCRIPTION
## Summary
- keep selection gestures active after multi-touch or double-drag detection so vertical moves continue selecting instead of reverting to plain cursor movement
- increase acceleration in non-precision cursor/delete sliding by reducing step size, while keeping precision mode unchanged
- preserve selection stickiness at gesture end to avoid clearing active selections mid-drag

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ccda18f348327abc8fa5b4d6063f1)