### PR TITLE
Expand cursor drag overlays

### DIFF
--- a/java/res/layout/input_view.xml
+++ b/java/res/layout/input_view.xml
@@ -22,6 +22,8 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:clipChildren="false"
+    android:clipToPadding="false"
     style="?attr/inputViewStyle">
     <include
         android:id="@+id/main_keyboard_frame"
@@ -29,8 +31,9 @@
     <TextView
         android:id="@+id/cursor_overlay_top"
         android:layout_width="match_parent"
-        android:layout_height="32dp"
+        android:layout_height="72dp"
         android:layout_gravity="top"
+        android:layout_marginTop="-16dp"
         android:background="@color/key_background_lxx_light"
         android:gravity="center"
         android:textColor="@color/key_text_color_lxx_light"
@@ -39,8 +42,9 @@
     <TextView
         android:id="@+id/cursor_overlay_bottom"
         android:layout_width="match_parent"
-        android:layout_height="32dp"
+        android:layout_height="72dp"
         android:layout_gravity="bottom"
+        android:layout_marginBottom="-16dp"
         android:background="@color/gesture_trail_color_lxx_dark"
         android:gravity="center"
         android:textColor="@color/key_text_color_lxx_dark"


### PR DESCRIPTION
## Summary
- expand cursor drag overlays to be taller and extend slightly beyond the keyboard bounds
- disable clipping in the input view so the enlarged overlays remain visible when shown

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ce852120883279efeb761452c177d)