### PR TITLE
Increase cursor drag pad area

### DIFF
--- a/java/res/layout/input_view.xml
+++ b/java/res/layout/input_view.xml
@@ -22,6 +22,10 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:clipChildren="false"
+    android:clipToPadding="false"
+    android:paddingTop="@dimen/cursor_pad_vertical_extension"
+    android:paddingBottom="@dimen/cursor_pad_vertical_extension"
     style="?attr/inputViewStyle">
     <include
         android:id="@+id/main_keyboard_frame"
@@ -29,8 +33,9 @@
     <TextView
         android:id="@+id/cursor_overlay_top"
         android:layout_width="match_parent"
-        android:layout_height="32dp"
+        android:layout_height="72dp"
         android:layout_gravity="top"
+        android:layout_marginTop="-16dp"
         android:background="@color/key_background_lxx_light"
         android:gravity="center"
         android:textColor="@color/key_text_color_lxx_light"
@@ -39,8 +44,9 @@
     <TextView
         android:id="@+id/cursor_overlay_bottom"
         android:layout_width="match_parent"
-        android:layout_height="32dp"
+        android:layout_height="72dp"
         android:layout_gravity="bottom"
+        android:layout_marginBottom="-16dp"
         android:background="@color/gesture_trail_color_lxx_dark"
         android:gravity="center"
         android:textColor="@color/key_text_color_lxx_dark"

--- a/java/res/values/dimens.xml
+++ b/java/res/values/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="cursor_pad_vertical_extension">48dp</dimen>
+</resources>

--- a/java/src/org/futo/inputmethod/latin/InputView.java
+++ b/java/src/org/futo/inputmethod/latin/InputView.java
@@ -21,6 +21,7 @@ import android.graphics.Rect;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.TouchDelegate;
 import android.widget.FrameLayout;
 
 import org.futo.inputmethod.accessibility.AccessibilityUtils;
@@ -32,6 +33,7 @@ public final class InputView extends FrameLayout {
     private MotionEventForwarder<?, ?> mActiveForwarder;
     private View mOverlayTop;
     private View mOverlayBottom;
+    private int mCursorPadVerticalExtension;
 
     public InputView(final Context context, final AttributeSet attrs) {
         super(context, attrs, 0);
@@ -43,6 +45,25 @@ public final class InputView extends FrameLayout {
         mMainKeyboardView = (MainKeyboardView) findViewById(R.id.keyboard_view);
         mOverlayTop = findViewById(R.id.cursor_overlay_top);
         mOverlayBottom = findViewById(R.id.cursor_overlay_bottom);
+        mCursorPadVerticalExtension = getResources()
+                .getDimensionPixelSize(R.dimen.cursor_pad_vertical_extension);
+    }
+
+    @Override
+    protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
+        super.onLayout(changed, left, top, right, bottom);
+
+        if (mMainKeyboardView == null) {
+            setTouchDelegate(null);
+            return;
+        }
+
+        final Rect delegateArea = new Rect();
+        mMainKeyboardView.getHitRect(delegateArea);
+        delegateArea.top -= mCursorPadVerticalExtension;
+        delegateArea.bottom += mCursorPadVerticalExtension;
+
+        setTouchDelegate(new TouchDelegate(delegateArea, mMainKeyboardView));
     }
 
     @Override


### PR DESCRIPTION
## Summary
- add extra padding around the input view to provide more cursor drag room beyond the keyboard bounds
- expand the main keyboard touch delegate to forward touches from the enlarged cursor pad region
- define a shared dimension for the extended cursor pad space

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ce852120883279efeb761452c177d)