### PR TITLE
Enable joystick cursor mode on spacebar long press

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Check out the [FUTO Keyboard website](https://keyboard.futo.org/) for downloads 
 - T9 multi-tap now replaces the previous letter instead of inserting multiple characters and backspace obeys the "delete whole words" option.
 - Long‑press spacebar drag now moves the cursor vertically when sliding up or down.
 - Colored overlays appear above and below the keyboard when dragging on the spacebar to show vertical and horizontal cursor control.
+- Holding the spacebar now locks into a joystick-style cursor mode for precise navigation.
 - Custom themes can set different background colors for each settings item icon.
 - Settings icons can also use custom background images loaded from files.
 - A file picker lets you choose a background image for the keyboard layout.

--- a/java/src/org/futo/inputmethod/keyboard/PointerTracker.java
+++ b/java/src/org/futo/inputmethod/keyboard/PointerTracker.java
@@ -1196,27 +1196,6 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
         }
         final int code = key.getCode();
         if (code == Constants.CODE_SPACE || code == Constants.CODE_LANGUAGE_SWITCH) {
-            int spacebarMode = Settings.getInstance().getCurrent().mSpacebarMode;
-            if(spacebarMode == Settings.SPACEBAR_MODE_SWIPE_LANGUAGE) {
-                mSpacebarLongPressed = true;
-                mStartX = mLastX;
-                mStartY = mLastY;
-                sListener.onMovingCursorLockEvent(true);
-                return;
-            } else if(spacebarMode == Settings.SPACEBAR_MODE_SWIPE_CURSOR_ONLY) {
-                mSpacebarLongPressed = true;
-                mStartX = mLastX;
-                mStartY = mLastY;
-                sListener.onMovingCursorLockEvent(true);
-                return;
-            }
-
-            // Long pressing the space key invokes IME switcher dialog.
-            if (sListener.onCustomRequest(Constants.CUSTOM_CODE_SHOW_INPUT_METHOD_PICKER)) {
-                cancelKeyTracking();
-                sListener.onReleaseKey(code, false /* withSliding */);
-                return;
-            }
             mSpacebarLongPressed = true;
             mStartX = mLastX;
             mStartY = mLastY;


### PR DESCRIPTION
## Summary
- make spacebar and language switch long presses immediately enter cursor movement mode instead of opening the IME picker
- document the joystick-style cursor navigation in the README

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d1187bcd88327acff529fa283860b)