### PR TITLE
Fix cursor lock movement handling braces

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Check out the [FUTO Keyboard website](https://keyboard.futo.org/) for downloads 
 - T9 multi-tap now replaces the previous letter instead of inserting multiple characters and backspace obeys the "delete whole words" option.
 - Long‑press spacebar drag now moves the cursor vertically when sliding up or down.
 - Colored overlays appear above and below the keyboard when dragging on the spacebar to show vertical and horizontal cursor control.
+- Holding the spacebar now locks into a joystick-style cursor mode that keeps the cursor gliding while your finger stays off-center.
 - Custom themes can set different background colors for each settings item icon.
 - Settings icons can also use custom background images loaded from files.
 - A file picker lets you choose a background image for the keyboard layout.

--- a/java/res/drawable/cursor_joystick_background.xml
+++ b/java/res/drawable/cursor_joystick_background.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="oval">
+    <size android:width="72dp" android:height="72dp" />
+    <solid android:color="@color/gesture_trail_color_lxx_dark" />
+    <stroke android:width="2dp" android:color="@color/key_text_color_lxx_dark" />
+    <padding android:left="12dp" android:top="12dp" android:right="12dp" android:bottom="12dp" />
+</shape>

--- a/java/res/layout/input_view.xml
+++ b/java/res/layout/input_view.xml
@@ -46,4 +46,11 @@
         android:textColor="@color/key_text_color_lxx_dark"
         android:text="@string/cursor_overlay_horizontal"
         android:visibility="gone" />
+    <View
+        android:id="@+id/cursor_overlay_center"
+        android:layout_width="72dp"
+        android:layout_height="72dp"
+        android:layout_gravity="center"
+        android:background="@drawable/cursor_joystick_background"
+        android:visibility="gone" />
 </org.futo.inputmethod.latin.InputView>

--- a/java/src/org/futo/inputmethod/keyboard/PointerTracker.java
+++ b/java/src/org/futo/inputmethod/keyboard/PointerTracker.java
@@ -18,6 +18,8 @@ package org.futo.inputmethod.keyboard;
 
 import android.content.res.Resources;
 import android.content.res.TypedArray;
+import android.os.Handler;
+import android.os.Looper;
 import android.os.SystemClock;
 import android.util.Log;
 import android.view.MotionEvent;
@@ -150,6 +152,11 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
     private boolean mStartedOnFastLongPress;
     private boolean mCursorMoved = false;
     private boolean mSpacebarLongPressed = false;
+    private boolean mIsCursorLocked = false;
+    private int mCursorLockOriginX = 0;
+    private int mCursorLockOriginY = 0;
+    private int mCursorLockStepX = 0;
+    private int mCursorLockStepY = 0;
 
     // true if keyboard layout has been changed.
     private boolean mKeyboardLayoutHasBeenChanged;
@@ -168,6 +175,29 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
     boolean mIsInSlidingKeyInput;
     // if not a NOT_A_CODE, the key of this code is repeating
     private int mCurrentRepeatingKeyCode = Constants.NOT_A_CODE;
+
+    private static final Handler sCursorLockHandler = new Handler(Looper.getMainLooper());
+    private static final long CURSOR_LOCK_REPEAT_INTERVAL = 35L;
+
+    private final Runnable mCursorLockRunnable = new Runnable() {
+        @Override
+        public void run() {
+            if (!mIsCursorLocked) {
+                return;
+            }
+
+            if (mCursorLockStepX != 0) {
+                sListener.onMovePointer(mCursorLockStepX);
+            }
+            if (mCursorLockStepY != 0) {
+                sListener.onMovePointerVertical(mCursorLockStepY);
+            }
+
+            if (mCursorLockStepX != 0 || mCursorLockStepY != 0) {
+                sCursorLockHandler.postDelayed(this, CURSOR_LOCK_REPEAT_INTERVAL);
+            }
+        }
+    };
 
     // true if dragging finger is allowed.
     private boolean mIsAllowedDraggingFinger;
@@ -745,8 +775,11 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
             mStartTime = System.currentTimeMillis();
             mStartedOnFastLongPress = key.isFastLongPress();
             mSpacebarLongPressed = false;
+            stopCursorLock();
 
-            mIsSlidingCursor = key.getCode() == Constants.CODE_DELETE || key.getCode() == Constants.CODE_SPACE;
+            mIsSlidingCursor = key.getCode() == Constants.CODE_DELETE
+                    || key.getCode() == Constants.CODE_SPACE
+                    || key.getCode() == Constants.CODE_LANGUAGE_SWITCH;
             mIsFlickingKey = !mIsSlidingCursor && key.getHasFlick();
             mFlickDirection = key.flickDirection(0, 0);
             mCurrentKey = key;
@@ -954,9 +987,13 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
 
         final SettingsValues settingsValues = Settings.getInstance().getCurrent();
 
-        if (mIsSlidingCursor && oldKey != null && oldKey.getCode() == Constants.CODE_SPACE) {
+        if (mIsSlidingCursor && oldKey != null
+                && (oldKey.getCode() == Constants.CODE_SPACE
+                || (oldKey.getCode() == Constants.CODE_LANGUAGE_SWITCH && mSpacebarLongPressed))) {
             int pointerStep = sPointerStep;
-            if(settingsValues.mSpacebarMode == Settings.SPACEBAR_MODE_SWIPE_LANGUAGE && !mSpacebarLongPressed) {
+            if(oldKey.getCode() == Constants.CODE_SPACE
+                    && settingsValues.mSpacebarMode == Settings.SPACEBAR_MODE_SWIPE_LANGUAGE
+                    && !mSpacebarLongPressed) {
                 pointerStep = sPointerHugeStep;
             }
 
@@ -967,7 +1004,9 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
                 mCursorMoved = true;
                 mStartX += steps * pointerStep;
 
-                if(settingsValues.mSpacebarMode == Settings.SPACEBAR_MODE_SWIPE_LANGUAGE && !mSpacebarLongPressed) {
+                if(oldKey.getCode() == Constants.CODE_SPACE
+                        && settingsValues.mSpacebarMode == Settings.SPACEBAR_MODE_SWIPE_LANGUAGE
+                        && !mSpacebarLongPressed) {
                     sListener.onSwipeLanguage(steps);
                 } else {
                     sListener.onMovePointer(steps);
@@ -978,6 +1017,10 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
                 mCursorMoved = true;
                 mStartY += vsteps * pointerStep;
                 sListener.onMovePointerVertical(vsteps);
+            }
+
+            if (mSpacebarLongPressed && pointerStep > 0) {
+                updateCursorLockSteps(x, y, pointerStep);
             }
 
             mLastX = x;
@@ -1056,6 +1099,48 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
         }
     }
 
+    private void startCursorLock(final int originX, final int originY) {
+        mIsCursorLocked = true;
+        mCursorLockOriginX = originX;
+        mCursorLockOriginY = originY;
+        mCursorLockStepX = 0;
+        mCursorLockStepY = 0;
+        sCursorLockHandler.removeCallbacks(mCursorLockRunnable);
+    }
+
+    private void updateCursorLockSteps(final int x, final int y, final int pointerStep) {
+        if (!mIsCursorLocked) {
+            return;
+        }
+
+        int stepX = (x - mCursorLockOriginX) / pointerStep;
+        int stepY = (y - mCursorLockOriginY) / pointerStep;
+
+        stepX = Math.max(-3, Math.min(3, stepX));
+        stepY = Math.max(-3, Math.min(3, stepY));
+
+        final boolean hadDirection = mCursorLockStepX != 0 || mCursorLockStepY != 0;
+        mCursorLockStepX = stepX;
+        mCursorLockStepY = stepY;
+
+        if (stepX == 0 && stepY == 0) {
+            if (hadDirection) {
+                sCursorLockHandler.removeCallbacks(mCursorLockRunnable);
+            }
+            return;
+        }
+
+        sCursorLockHandler.removeCallbacks(mCursorLockRunnable);
+        sCursorLockHandler.postDelayed(mCursorLockRunnable, CURSOR_LOCK_REPEAT_INTERVAL);
+    }
+
+    private void stopCursorLock() {
+        mIsCursorLocked = false;
+        mCursorLockStepX = 0;
+        mCursorLockStepY = 0;
+        sCursorLockHandler.removeCallbacks(mCursorLockRunnable);
+    }
+
     private void onUpEvent(final int x, final int y, final long eventTime) {
         if (DEBUG_EVENT) {
             printTouchEvent("onUpEvent  :", x, y, eventTime);
@@ -1100,6 +1185,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
         mCurrentRepeatingKeyCode = Constants.NOT_A_CODE;
         // Release the last pressed key.
         setReleasedKeyGraphics(currentKey, true /* withAnimation */);
+        stopCursorLock();
 
         if (mCursorMoved && currentKey != null && currentKey.getCode() == Constants.CODE_DELETE) {
             sListener.onUpWithDeletePointerActive();
@@ -1196,28 +1282,8 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
         }
         final int code = key.getCode();
         if (code == Constants.CODE_SPACE || code == Constants.CODE_LANGUAGE_SWITCH) {
-            int spacebarMode = Settings.getInstance().getCurrent().mSpacebarMode;
-            if(spacebarMode == Settings.SPACEBAR_MODE_SWIPE_LANGUAGE) {
-                mSpacebarLongPressed = true;
-                mStartX = mLastX;
-                mStartY = mLastY;
-                sListener.onMovingCursorLockEvent(true);
-                return;
-            } else if(spacebarMode == Settings.SPACEBAR_MODE_SWIPE_CURSOR_ONLY) {
-                mSpacebarLongPressed = true;
-                mStartX = mLastX;
-                mStartY = mLastY;
-                sListener.onMovingCursorLockEvent(true);
-                return;
-            }
-
-            // Long pressing the space key invokes IME switcher dialog.
-            if (sListener.onCustomRequest(Constants.CUSTOM_CODE_SHOW_INPUT_METHOD_PICKER)) {
-                cancelKeyTracking();
-                sListener.onReleaseKey(code, false /* withSliding */);
-                return;
-            }
             mSpacebarLongPressed = true;
+            startCursorLock(mLastX, mLastY);
             mStartX = mLastX;
             mStartY = mLastY;
             sListener.onMovingCursorLockEvent(true);
@@ -1268,6 +1334,7 @@ public final class PointerTracker implements PointerTrackerQueue.Element,
         setReleasedKeyGraphics(mCurrentKey, true /* withAnimation */);
         resetKeySelectionByDraggingFinger();
         dismissMoreKeysPanel();
+        stopCursorLock();
 
         // Cancel any active cursor movement overlays
         sListener.onMovingCursorLockEvent(false);

--- a/java/src/org/futo/inputmethod/latin/InputView.java
+++ b/java/src/org/futo/inputmethod/latin/InputView.java
@@ -32,6 +32,7 @@ public final class InputView extends FrameLayout {
     private MotionEventForwarder<?, ?> mActiveForwarder;
     private View mOverlayTop;
     private View mOverlayBottom;
+    private View mOverlayCenter;
 
     public InputView(final Context context, final AttributeSet attrs) {
         super(context, attrs, 0);
@@ -43,6 +44,7 @@ public final class InputView extends FrameLayout {
         mMainKeyboardView = (MainKeyboardView) findViewById(R.id.keyboard_view);
         mOverlayTop = findViewById(R.id.cursor_overlay_top);
         mOverlayBottom = findViewById(R.id.cursor_overlay_bottom);
+        mOverlayCenter = findViewById(R.id.cursor_overlay_center);
     }
 
     @Override
@@ -83,8 +85,27 @@ public final class InputView extends FrameLayout {
     }
 
     public void showCursorOverlays(boolean show) {
-        if (mOverlayTop != null) mOverlayTop.setVisibility(show ? View.VISIBLE : View.GONE);
-        if (mOverlayBottom != null) mOverlayBottom.setVisibility(show ? View.VISIBLE : View.GONE);
+        if (mOverlayTop != null) mOverlayTop.setVisibility(View.GONE);
+        if (mOverlayBottom != null) mOverlayBottom.setVisibility(View.GONE);
+
+        if (mOverlayCenter != null) {
+            if (show) {
+                mOverlayCenter.animate().cancel();
+                mOverlayCenter.setAlpha(0f);
+                mOverlayCenter.setScaleX(0.8f);
+                mOverlayCenter.setScaleY(0.8f);
+                mOverlayCenter.setVisibility(View.VISIBLE);
+                mOverlayCenter.animate()
+                        .alpha(1f)
+                        .scaleX(1f)
+                        .scaleY(1f)
+                        .setDuration(120L)
+                        .start();
+            } else {
+                mOverlayCenter.animate().cancel();
+                mOverlayCenter.setVisibility(View.GONE);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- fix the gesture handling block so cursor-lock move logic stays inside onMoveEventInternal
- relocate cursor lock helper methods outside the move handler to restore class structure

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d1187bcd88327acff529fa283860b)