### PR TITLE
Add setting to toggle collapse keyboard button

### DIFF
--- a/java/res/values/strings-uix.xml
+++ b/java/res/values/strings-uix.xml
@@ -495,6 +495,8 @@
     <string name="keyboard_settings_extra_layouts_subtitle">Configure additional layouts in the languages screen</string>
     <string name="keyboard_settings_show_suggestion_row">Show action/suggestions bar</string>
     <string name="keyboard_settings_show_suggestion_row_subtitle">Show the bar containing suggestions. Recommended to keep enabled</string>
+    <string name="keyboard_settings_show_collapse_button">Show collapse keyboard button</string>
+    <string name="keyboard_settings_show_collapse_button_subtitle">Display the down arrow that hides or expands the action bar</string>
     <string name="keyboard_settings_inline_autofill">Inline autofill</string>
     <string name="keyboard_settings_inline_autofill_subtitle">Display password manager autofill and auto-reply suggestions (provided by app) in suggestion bar</string>
     <string name="keyboard_settings_period_key">Quick period key</string>

--- a/java/src/org/futo/inputmethod/latin/uix/ActionBar.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/ActionBar.kt
@@ -122,6 +122,7 @@ import org.futo.inputmethod.latin.uix.actions.PinnedActions
 import org.futo.inputmethod.latin.uix.actions.toActionList
 import org.futo.inputmethod.latin.uix.settings.useDataStore
 import org.futo.inputmethod.latin.uix.settings.useDataStoreValue
+import org.futo.inputmethod.latin.uix.settings.pages.ShowCollapseKeyboardButtonSetting
 import org.futo.inputmethod.latin.uix.theme.ThemeOption
 import org.futo.inputmethod.latin.uix.theme.Typography
 import org.futo.inputmethod.latin.uix.theme.UixThemeWrapper
@@ -777,6 +778,7 @@ fun ActionBar(
     val context = LocalContext.current
 
     val oldActionBar = useDataStore(OldStyleActionsBar)
+    val showCollapseButton = useDataStore(ShowCollapseKeyboardButtonSetting)
 
     val useDoubleHeight = isActionsExpanded && oldActionBar.value == false
 
@@ -816,13 +818,15 @@ fun ActionBar(
                 .weight(1.0f), color = actionBarColor()
         ) {
             Row(Modifier.safeKeyboardPadding()) {
-                ExpandActionsButton(isActionsExpanded) {
-                    toggleActionsExpanded()
+                if(showCollapseButton.value) {
+                    ExpandActionsButton(isActionsExpanded) {
+                        toggleActionsExpanded()
 
-                    keyboardManagerForAction?.performHapticAndAudioFeedback(
-                        Constants.CODE_TAB,
-                        view
-                    )
+                        keyboardManagerForAction?.performHapticAndAudioFeedback(
+                            Constants.CODE_TAB,
+                            view
+                        )
+                    }
                 }
 
                 if(oldActionBar.value && isActionsExpanded) {
@@ -1172,6 +1176,7 @@ private fun RowScope.InlineCandidates(
 ) {
     val view = LocalView.current
     val expandHeight = with(LocalDensity.current) { 120.dp.toPx().coerceAtMost(keyboardHeight / 2.0f) }
+    val showCollapseButton = useDataStore(ShowCollapseKeyboardButtonSetting)
     Box(Modifier.weight(1.0f).fillMaxHeight()) {
         LazyRow(
             modifier = Modifier.matchParentSize().pointerInput(Unit) {
@@ -1200,18 +1205,20 @@ private fun RowScope.InlineCandidates(
             verticalAlignment = CenterVertically,
             state = lazyListState
         ) {
-            item {
-                val manager = LocalManager.current
-                if(closeActionWindow != null) {
-                    CloseActionWindowButton(closeActionWindow)
-                } else {
-                    ExpandActionsButton(isActionsExpanded) {
-                        toggleActionsExpanded()
+            if(showCollapseButton.value) {
+                item {
+                    val manager = LocalManager.current
+                    if(closeActionWindow != null) {
+                        CloseActionWindowButton(closeActionWindow)
+                    } else {
+                        ExpandActionsButton(isActionsExpanded) {
+                            toggleActionsExpanded()
 
-                        manager.performHapticAndAudioFeedback(
-                            Constants.CODE_TAB,
-                            view
-                        )
+                            manager.performHapticAndAudioFeedback(
+                                Constants.CODE_TAB,
+                                view
+                            )
+                        }
                     }
                 }
             }
@@ -1280,14 +1287,17 @@ fun BoxScope.ActionBarWithExpandableCandidates(
         } ?: emptyList()
     }
 
+    val showCollapseButton = useDataStore(ShowCollapseKeyboardButtonSetting)
+
     val suggestionsExpansion = remember { mutableFloatStateOf(0.0f) }
     val lazyListState = rememberLazyListState()
+    val startOfCandidates = if(showCollapseButton.value) START_OF_CANDIDATES else 0
 
     LaunchedEffect(wordList, words?.mHighlightedCandidate) {
         if(words?.mHighlightedCandidate != null) {
-            lazyListState.scrollToItem(words.mHighlightedCandidate + START_OF_CANDIDATES)
+            lazyListState.scrollToItem(words.mHighlightedCandidate + startOfCandidates)
         } else {
-            lazyListState.scrollToItem(START_OF_CANDIDATES)
+            lazyListState.scrollToItem(startOfCandidates)
         }
     }
 

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/Typing.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/Typing.kt
@@ -147,6 +147,11 @@ val ActionBarDisplayedSetting = SettingsKey(
     true
 )
 
+val ShowCollapseKeyboardButtonSetting = SettingsKey(
+    booleanPreferencesKey("show_collapse_keyboard_button"),
+    true
+)
+
 val InlineAutofillSetting = SettingsKey(
     booleanPreferencesKey("inline_autofill"),
     true
@@ -784,6 +789,11 @@ val KeyboardSettingsMenu = UserSettingsMenu(
             icon = {
                 Icon(painterResource(id = R.drawable.more_horizontal), contentDescription = null)
             }
+        ),
+        userSettingToggleDataStore(
+            title = R.string.keyboard_settings_show_collapse_button,
+            subtitle = R.string.keyboard_settings_show_collapse_button_subtitle,
+            setting = ShowCollapseKeyboardButtonSetting
         ),
         userSettingToggleDataStore(
             title = R.string.keyboard_settings_inline_autofill,


### PR DESCRIPTION
## Summary
- add a keyboard setting to toggle the collapse/expand button visibility
- wire the action bar to respect the setting when rendering its toggle control
- document the new option with user-facing strings

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d133508a08327ad7610abc5cf19b1)