### PR TITLE
Improve settings search matching

### DIFF
--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/Search.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/Search.kt
@@ -60,6 +60,49 @@ private fun normalizeString(s: String): String {
     } ?: s).lowercase()
 }
 
+private fun levenshteinDistance(a: String, b: String): Int {
+    if (a.isEmpty()) return b.length
+    if (b.isEmpty()) return a.length
+
+    val previousRow = IntArray(b.length + 1) { it }
+    val currentRow = IntArray(b.length + 1)
+
+    for (i in a.indices) {
+        currentRow[0] = i + 1
+        for (j in b.indices) {
+            val cost = if (a[i] == b[j]) 0 else 1
+            currentRow[j + 1] = minOf(
+                currentRow[j] + 1,
+                previousRow[j + 1] + 1,
+                previousRow[j] + cost
+            )
+        }
+        for (j in currentRow.indices) {
+            previousRow[j] = currentRow[j]
+        }
+    }
+
+    return previousRow.last()
+}
+
+private fun fuzzyMatches(query: String, candidate: String): Boolean {
+    if (candidate.contains(query)) return true
+
+    val distanceThreshold = (query.length / 4).coerceAtLeast(1).coerceAtMost(3)
+    val tokens = candidate.split("\n", " ").filter { it.isNotBlank() }
+
+    return tokens.any { levenshteinDistance(query, it) <= distanceThreshold }
+}
+
+private fun matchesQuery(query: String, searchableParts: List<String>): Boolean {
+    if (query.isBlank()) return false
+
+    val regex = runCatching { query.toRegex() }.getOrNull()
+    if (regex != null && searchableParts.any { regex.containsMatchIn(it) }) return true
+
+    return searchableParts.any { fuzzyMatches(query, it) }
+}
+
 @OptIn(ExperimentalFoundationApi::class)
 @Preview(showBackground = true)
 @Composable
@@ -73,11 +116,12 @@ fun SearchScreen(navController: NavHostController = rememberNavController()) {
             .filter { it.name != 0 }
             .associate {
                 it to run {
-                    normalizeString(context.getString(it.name)) + "\n" +
-                            (it.searchTagList?.joinToString("\n") { normalizeString(context.getString(it)) }
-                                ?: it.searchTags?.let { normalizeString(context.getString(it)) }
-                                ?: "") + "\n" +
-                            (it.subtitle?.let { normalizeString(context.getString(it)) } ?: "")
+                    buildList {
+                        add(normalizeString(context.getString(it.name)))
+                        it.searchTagList?.forEach { tag -> add(normalizeString(context.getString(tag))) }
+                        it.searchTags?.let { tag -> add(normalizeString(context.getString(tag))) }
+                        it.subtitle?.let { subtitle -> add(normalizeString(context.getString(subtitle))) }
+                    }.filter { value -> value.isNotBlank() }
                 }
             }
     }
@@ -87,7 +131,7 @@ fun SearchScreen(navController: NavHostController = rememberNavController()) {
         SettingsMenus.map { menu ->
             menu to menu.settings
                 .filter { it.name != 0 && it.appearsInSearch }
-                .filter { searchTagsByMenu[it]!!.contains(query) }
+                .filter { matchesQuery(query, searchTagsByMenu[it].orEmpty()) }
         }
     }.filter {
         it.first.visibilityCheck?.invoke() != false

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/Search.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/Search.kt
@@ -85,22 +85,77 @@ private fun levenshteinDistance(a: String, b: String): Int {
     return previousRow.last()
 }
 
+private fun jaroWinklerSimilarity(s1: String, s2: String): Double {
+    if (s1 == s2) return 1.0
+    if (s1.isEmpty() || s2.isEmpty()) return 0.0
+
+    val maxDist = (maxOf(s1.length, s2.length) / 2) - 1
+    val s1Matches = BooleanArray(s1.length)
+    val s2Matches = BooleanArray(s2.length)
+
+    var matches = 0
+    var transpositions = 0
+
+    for (i in s1.indices) {
+        val start = (i - maxDist).coerceAtLeast(0)
+        val end = (i + maxDist + 1).coerceAtMost(s2.length)
+
+        for (j in start until end) {
+            if (s2Matches[j]) continue
+            if (s1[i] != s2[j]) continue
+            s1Matches[i] = true
+            s2Matches[j] = true
+            matches++
+            break
+        }
+    }
+
+    if (matches == 0) return 0.0
+
+    var k = 0
+    for (i in s1.indices) {
+        if (!s1Matches[i]) continue
+        while (!s2Matches[k]) k++
+        if (s1[i] != s2[k]) transpositions++
+        k++
+    }
+
+    val m = matches.toDouble()
+    val jaro = (m / s1.length + m / s2.length + (m - transpositions / 2.0) / m) / 3.0
+
+    var prefix = 0
+    while (prefix < minOf(4, s1.length, s2.length) && s1[prefix] == s2[prefix]) {
+        prefix++
+    }
+
+    return jaro + prefix * 0.1 * (1 - jaro)
+}
+
 private fun fuzzyMatches(query: String, candidate: String): Boolean {
-    if (candidate.contains(query)) return true
+    if (candidate.contains(query) || query.contains(candidate)) return true
 
     val distanceThreshold = (query.length / 4).coerceAtLeast(1).coerceAtMost(3)
     val tokens = candidate.split("\n", " ").filter { it.isNotBlank() }
 
-    return tokens.any { levenshteinDistance(query, it) <= distanceThreshold }
+    val levenshteinHit = tokens.any { levenshteinDistance(query, it) <= distanceThreshold }
+    val jaroWinklerHit = tokens.any { jaroWinklerSimilarity(query, it) >= 0.82 }
+
+    return levenshteinHit || jaroWinklerHit
 }
 
 private fun matchesQuery(query: String, searchableParts: List<String>): Boolean {
     if (query.isBlank()) return false
 
+    val queryTokens = query.split(" ").filter { it.isNotBlank() }
+
     val regex = runCatching { query.toRegex() }.getOrNull()
     if (regex != null && searchableParts.any { regex.containsMatchIn(it) }) return true
 
-    return searchableParts.any { fuzzyMatches(query, it) }
+    // Require every query token to match at least one searchable token to better support
+    // multi-word queries while still allowing minor mistakes.
+    return queryTokens.all { token ->
+        searchableParts.any { fuzzyMatches(token, it) }
+    }
 }
 
 @OptIn(ExperimentalFoundationApi::class)

--- a/todo.txt
+++ b/todo.txt
@@ -22,11 +22,10 @@
 - [x] **Floating bar editing buttons** - Added undo (left), backspace, redo (right)
 - [x] **Clipboard entry layout** - Text displayed between pin and close icons
 
-## PENDING
 
 - [x] **Voice recognition button** - pill mode, floating bar mode, if i click on the voice recognition button second time, it does not paste into the text area. but it the clipboard i see it combines the text with the previous audio....i think it is sending combined audio to the server.
 
-- [ ] **Toast messages** - when toast messages happen, copying or other thing when keyboard is on, it appears on top of the keyboard obscuring some letters. i don't want that to happen. we can have/force the toast message above the keyboard.
+- [x] **Toast messages** - when toast messages happen, copying or other thing when keyboard is on, it appears on top of the keyboard obscuring some letters. i don't want that to happen. we can have/force the toast message above the keyboard.
 
 
 - [x] we should be able to skip the enable accessibility service grant permission at setup. later we should be able rerun the setup from inside  the settings section.
@@ -34,13 +33,16 @@
 
 voice-session-id-guard branch
 voice-session-id-guard
-- [ ] Add a sessionId guard to ignore stale callbacks (high value)
+- [x] Add a sessionId guard to ignore stale callbacks (high value)
 Why: Even after reset()/cancelAll(), there can be edge cases where an old coroutine finishes late and calls listener.finished() or partialResult() for the previous session. This can look like “2nd run commits old text” or “mixed results”.
 - How (concept):
     - In AudioRecognizer, add private var sessionId: Long = 0
     - Increment sessionId in reset() and at the start of startRecording()
     - Capture the current id inside runModel() and before each listener.partialResult(...) / listener.finished(...), verify the id still matches.
 
+
+## PENDING
+- [ ] option to enable disable the hide keyboard button in settings. the button is present at the lower left corner of the keyboard.
 
 - [ ] **Keyboard horizontal positioning** - Move keyboard left/right when resized (not just centered)
 - [ ] **Settings search image paste** - Support pasting images in settings search field


### PR DESCRIPTION
## Summary
- normalize settings search tags to individual tokens for better matching
- add fuzzy and regex-based matching to settings search results

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e06558304832784733a287c63ac38)