### PR TITLE
Keep pinned actions visible with inline suggestions

### DIFF
--- a/java/src/org/futo/inputmethod/latin/uix/ActionBar.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/ActionBar.kt
@@ -835,9 +835,9 @@ fun ActionBar(
                     if (importantNotice != null) {
                         ImportantNoticeView(importantNotice)
                     } else {
-                        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
-                            && inlineSuggestions.isNotEmpty()
-                        ) {
+                        val showingInlineSuggestions = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && inlineSuggestions.isNotEmpty()
+
+                        if(showingInlineSuggestions) {
                             InlineSuggestions(inlineSuggestions)
                         } else if(quickClipState != null) {
                             QuickClipView(quickClipState, onQuickClipDismiss)
@@ -862,9 +862,7 @@ fun ActionBar(
                             Spacer(modifier = Modifier.weight(1.0f))
                         }
 
-                        if(inlineSuggestions.isEmpty()) {
-                            PinnedActionItems(onActionActivated, onActionAltActivated)
-                        }
+                        PinnedActionItems(onActionActivated, onActionAltActivated)
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- keep pinned actions visible even when inline suggestions are shown so voice input stays accessible
- clarify inline suggestion handling with a visibility flag

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e4edd23d8832794709e5ee0389369)