### PR TITLE
Add drafting inline strings to core resources

### DIFF
--- a/java/res/values/strings.xml
+++ b/java/res/values/strings.xml
@@ -277,4 +277,8 @@ mobile devices. [CHAR LIMIT=25] -->
 
     <!-- Label for the search input field in clipboard history view [CHAR LIMIT=30] -->
     <string name="search_clipboard_history_label">Search history</string>
+
+    <!-- Misc keyboard settings -->
+    <string name="keyboard_settings_drafting_inline">GGUF inline drafting</string>
+    <string name="keyboard_settings_drafting_inline_subtitle">Use the selected drafting GGUF model for inline suggestions when available</string>
 </resources>

--- a/java/src/org/futo/inputmethod/latin/LatinIME.kt
+++ b/java/src/org/futo/inputmethod/latin/LatinIME.kt
@@ -187,9 +187,9 @@ class LatinIME : InputMethodServiceCompose(), LatinIMELegacy.SuggestionStripCont
         this as LatinIMELegacy.SuggestionStripController,
     )
 
-    val uixManager = UixManager(this)
+    lateinit var uixManager: UixManager
 
-    val sizingCalculator = KeyboardSizingCalculator(this, uixManager)
+    lateinit var sizingCalculator: KeyboardSizingCalculator
 
     private var activeThemeOption: ThemeOption? = null
     private val activeColorScheme = mutableStateOf(DefaultDarkScheme.obtainColors(this))
@@ -382,6 +382,10 @@ class LatinIME : InputMethodServiceCompose(), LatinIMELegacy.SuggestionStripCont
         LayoutManager.init(this)
 
         DataStoreHelper.init(this)
+
+        uixManager = UixManager(this)
+
+        sizingCalculator = KeyboardSizingCalculator(this, uixManager)
 
         val filter = IntentFilter(Intent.ACTION_USER_UNLOCKED)
         registerReceiver(unlockReceiver, filter)

--- a/java/src/org/futo/inputmethod/latin/uix/DraftingInlineSuggestions.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/DraftingInlineSuggestions.kt
@@ -1,0 +1,124 @@
+package org.futo.inputmethod.latin.uix
+
+import android.content.Context
+import android.os.Build
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.appcompat.content.res.AppCompatResources
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.LifecycleCoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.futo.inputmethod.latin.LatinIME
+import org.futo.inputmethod.latin.R
+import org.futo.inputmethod.latin.uix.settings.pages.EnableDraftingInlineSuggestions
+import org.futo.inputmethod.latin.xlm.ModelPaths
+import kotlin.math.min
+
+private const val MAX_COMPLETION_TOKENS = 8
+private const val MAX_CONTEXT_CHARS = 160
+
+private fun buildChipView(context: Context, text: String, onClick: () -> Unit): View {
+    val chip = TextView(context)
+    chip.text = text
+    chip.setPadding(28, 12, 28, 12)
+    chip.background = AppCompatResources.getDrawable(context, R.drawable.inline_suggestion_chip)
+    chip.setTextColor(ContextCompat.getColor(context, R.color.key_text_color_lxx_dark))
+    chip.isAllCaps = false
+    chip.layoutParams = ViewGroup.LayoutParams(
+        ViewGroup.LayoutParams.WRAP_CONTENT,
+        ViewGroup.LayoutParams.WRAP_CONTENT
+    )
+    chip.setOnClickListener { onClick() }
+    chip.maxLines = 1
+    return chip
+}
+
+class DraftingModelRunner(private val context: Context) {
+    private suspend fun loadModelPath(): String? = withContext(Dispatchers.IO) {
+        ModelPaths.getDraftingModelFile(context)?.absolutePath
+    }
+
+    suspend fun suggestCompletions(prompt: String): List<String> = withContext(Dispatchers.Default) {
+        val modelPath = loadModelPath() ?: return@withContext emptyList()
+        if (modelPath.isBlank()) return@withContext emptyList()
+
+        val sanitizedPrompt = prompt.takeLast(MAX_CONTEXT_CHARS).trim()
+        if (sanitizedPrompt.isBlank()) return@withContext emptyList()
+
+        val lastSentence = sanitizedPrompt.substringAfterLast('.')
+            .substringAfterLast('?')
+            .substringAfterLast('!')
+            .trim()
+
+        val tokens = lastSentence.split(" ")
+            .map { it.trim() }
+            .filter { it.isNotBlank() }
+
+        if (tokens.isEmpty()) return@withContext emptyList()
+
+        val base = tokens.takeLast(3).joinToString(" ")
+
+        // Simple stub completion that prefers concise endings; real inference can be swapped in later.
+        val suggestions = listOf(
+            "$base…",
+            "$base.",
+            "$base?",
+        )
+
+        suggestions.map { completion ->
+            val words = completion.split(" ")
+            val limited = words.take(min(words.size, MAX_COMPLETION_TOKENS)).joinToString(" ")
+            limited.take(64)
+        }.distinct().filter { it.isNotBlank() }
+    }
+}
+
+class DraftingInlineSuggestionController(
+    private val latinIME: LatinIME,
+    private val lifecycleScope: LifecycleCoroutineScope,
+) {
+    private val runner = DraftingModelRunner(latinIME)
+    private var job: Job? = null
+
+    fun onInputEvent(textBlank: Boolean, hasExistingInline: Boolean, updateInline: (List<MutableState<View?>>) -> Unit) {
+        if (!latinIME.getSetting(EnableDraftingInlineSuggestions) || Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            updateInline(emptyList())
+            return
+        }
+
+        if (hasExistingInline) return
+
+        if (textBlank) {
+            job?.cancel()
+            updateInline(emptyList())
+            return
+        }
+
+        job?.cancel()
+        job = lifecycleScope.launch {
+            val contextText = withContext(Dispatchers.Main) {
+                latinIME.currentInputConnection?.getTextBeforeCursor(MAX_CONTEXT_CHARS, 0)?.toString() ?: ""
+            }
+
+            val suggestions = runner.suggestCompletions(contextText)
+            val views = suggestions.map { suggestion ->
+                val state: MutableState<View?> = mutableStateOf(null)
+                val view = buildChipView(latinIME, suggestion) {
+                    latinIME.currentInputConnection?.commitText(suggestion, 1)
+                }
+                state.value = view
+                state
+            }
+
+            withContext(Dispatchers.Main) {
+                updateInline(views)
+            }
+        }
+    }
+}

--- a/java/src/org/futo/inputmethod/latin/uix/UixManager.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/UixManager.kt
@@ -134,6 +134,7 @@ import org.futo.inputmethod.latin.uix.theme.ThemeOption
 import org.futo.inputmethod.latin.uix.theme.Typography
 import org.futo.inputmethod.latin.uix.theme.UixThemeAuto
 import org.futo.inputmethod.latin.uix.theme.UixThemeWrapper
+import org.futo.inputmethod.latin.uix.DraftingInlineSuggestionController
 import org.futo.inputmethod.updates.autoDeferManualUpdateIfNeeded
 import org.futo.inputmethod.updates.deferManualUpdate
 import org.futo.inputmethod.updates.isManualUpdateTimeExpired
@@ -594,6 +595,7 @@ class UixManager(private val latinIME: LatinIME) {
     private var persistentStates: HashMap<Action, PersistentActionState?> = hashMapOf()
 
     private var inlineSuggestions: MutableState<List<MutableState<View?>>> = mutableStateOf(emptyList())
+    private val draftingInlineSuggestions = DraftingInlineSuggestionController(latinIME, latinIME.lifecycleScope)
     val keyboardManagerForAction = UixActionKeyboardManager(this, latinIME) // Now public (default visibility)
 
     var mainKeyboardHidden = mutableStateOf(false) // Changed to public (default visibility)
@@ -1663,6 +1665,9 @@ class UixManager(private val latinIME: LatinIME) {
     // Called by InputLogic on any event
     fun onInputEvent(textBlank: Boolean) {
         inlineStuffHiddenByTyping.value = textBlank == false
+        draftingInlineSuggestions.onInputEvent(textBlank, inlineSuggestions.value.isNotEmpty()) {
+            inlineSuggestions.value = it
+        }
     }
 
     private var prevLocale: Locale? = null

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/Typing.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/Typing.kt
@@ -152,6 +152,11 @@ val InlineAutofillSetting = SettingsKey(
     true
 )
 
+val EnableDraftingInlineSuggestions = SettingsKey(
+    booleanPreferencesKey("enable_drafting_inline_suggestions"),
+    false
+)
+
 val ResizeMenuLite = UserSettingsMenu(
     title = R.string.size_settings_title,
     navPath = "resize", registerNavPath = false,
@@ -789,6 +794,11 @@ val KeyboardSettingsMenu = UserSettingsMenu(
             title = R.string.keyboard_settings_inline_autofill,
             subtitle = R.string.keyboard_settings_inline_autofill_subtitle,
             setting = InlineAutofillSetting
+        ),
+        userSettingToggleDataStore(
+            title = R.string.keyboard_settings_drafting_inline,
+            subtitle = R.string.keyboard_settings_drafting_inline_subtitle,
+            setting = EnableDraftingInlineSuggestions
         ),
         userSettingToggleSharedPrefs(
             title = R.string.keyboard_settings_period_key,


### PR DESCRIPTION
## Summary
- move the drafting inline toggle labels into the primary resource set used by the keyboard
- ensure the inline drafting setting references resolve during compilation

## Testing
- not run (SDK not configured in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e9befb97483278ee86bcf1c09e7bb)