### PR TITLE
Add debug logging to drafting inline suggestion controller

### DIFF
--- a/java/src/org/futo/inputmethod/latin/uix/DraftingInlineSuggestions.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/DraftingInlineSuggestions.kt
@@ -1,0 +1,54 @@
+package org.futo.inputmethod.latin.uix
+
+import android.os.Build
+import android.util.Log
+import android.view.inputmethod.InlineSuggestion
+import androidx.annotation.RequiresApi
+
+private const val TAG = "DraftingInline"
+
+class DraftingInlineSuggestionController {
+    @RequiresApi(Build.VERSION_CODES.R)
+    fun onInputEvent(
+        inlineToggleEnabled: Boolean,
+        hasExistingInlineSuggestion: Boolean,
+        textIsBlank: Boolean,
+        cursorContext: CharSequence?,
+        suggestions: List<InlineSuggestion>,
+        onChipCreated: (InlineSuggestion) -> Unit = {},
+        onChipCommitted: (InlineSuggestion) -> Unit = {}
+    ) {
+        Log.d(TAG, "toggle=$inlineToggleEnabled apiOk=${Build.VERSION.SDK_INT >= Build.VERSION_CODES.R}")
+
+        if (!inlineToggleEnabled) {
+            Log.d(TAG, "inline disabled")
+            return
+        }
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            Log.d(TAG, "api too low")
+            return
+        }
+
+        if (hasExistingInlineSuggestion) {
+            Log.d(TAG, "existing inline suggestion")
+            return
+        }
+
+        if (textIsBlank) {
+            Log.d(TAG, "blank text")
+            return
+        }
+
+        Log.d(TAG, "cursorContextLen=${cursorContext?.length ?: 0}")
+        Log.d(TAG, "suggestionCount=${suggestions.size}")
+
+        val suggestion = suggestions.firstOrNull() ?: return
+
+        Log.d(TAG, "chipCreated")
+        onChipCreated(suggestion)
+
+        Log.d(TAG, "chipCommitted")
+        onChipCommitted(suggestion)
+    }
+}


### PR DESCRIPTION
## Summary
- add a DraftingInlineSuggestionController file with onInputEvent logging for toggle/API checks, early returns, context length, and chip handling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693eb20a5c34832785a113999e4a472c)