### PR TITLE
Finish voice recognition on back press and hide keyboard after commit

### DIFF
--- a/java/src/org/futo/inputmethod/latin/uix/actions/VoiceInputAction.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/VoiceInputAction.kt
@@ -226,6 +226,7 @@ private class VoiceInputActionWindow(
     private var modelException: MutableState<ModelDoesNotExistException?> = mutableStateOf(null)
     private var isListening = false
     private var closeAfterFinish = false
+    private var finishRequested = false
 
     private val initJob = manager.getLifecycleScope().launch {
         yield()
@@ -291,6 +292,14 @@ private class VoiceInputActionWindow(
 
     override fun close(): CloseResult {
         if (isListening) {
+            if (finishRequested) {
+                finishRequested = false
+                closeAfterFinish = false
+                recognizerView.value?.cancel()
+                isListening = false
+                return CloseResult.Default
+            }
+            finishRequested = true
             closeAfterFinish = true
             recognizerView.value?.finish()
             return CloseResult.PreventClosing
@@ -313,10 +322,14 @@ private class VoiceInputActionWindow(
             inputTransaction.cancel()
         }
         isListening = false
+        finishRequested = false
         if (closeAfterFinish) {
             closeAfterFinish = false
             manager.closeActionWindow()
-            manager.getLatinIMEForDebug().requestHideSelf(0)
+            manager.getLifecycleScope().launch(Dispatchers.Main) {
+                delay(50)
+                manager.getLatinIMEForDebug().requestHideSelf(0)
+            }
         }
     }
 
@@ -340,6 +353,7 @@ private class VoiceInputActionWindow(
 
         manager.getLifecycleScope().launch(Dispatchers.Main) {
             isListening = false
+            finishRequested = false
             val sanitized = ModelOutputSanitizer.sanitize(result, inputTransaction.textContext, manager.isCapsLocked())
             inputTransaction.commit(sanitized)
             val clipboardManager = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
@@ -349,6 +363,7 @@ private class VoiceInputActionWindow(
             manager.closeActionWindow()
             if (closeAfterFinish) {
                 closeAfterFinish = false
+                delay(50)
                 manager.getLatinIMEForDebug().requestHideSelf(0)
             }
         }
@@ -462,6 +477,7 @@ private class VoiceInputBottomBarWindow(
     private var recognizerView: MutableState<RecognizerView?> = mutableStateOf(null)
     private var modelException: MutableState<ModelDoesNotExistException?> = mutableStateOf(null)
     private var closeAfterFinish = false
+    private var finishRequested = false
 
     private val initJob = manager.getLifecycleScope().launch {
         yield()
@@ -827,6 +843,15 @@ private class VoiceInputBottomBarWindow(
 
     override fun close(): CloseResult {
         if (isListening.value) {
+            if (finishRequested) {
+                finishRequested = false
+                closeAfterFinish = false
+                recognizerView.value?.cancel()
+                isListening.value = false
+                statusText.value = "Cancelled"
+                return CloseResult.Default
+            }
+            finishRequested = true
             closeAfterFinish = true
             statusText.value = "Stopping…"
             recognizerView.value?.finish()
@@ -853,10 +878,14 @@ private class VoiceInputBottomBarWindow(
         }
         isListening.value = false
         statusText.value = "Cancelled"
+        finishRequested = false
         if (closeAfterFinish) {
             closeAfterFinish = false
-            manager.closeActionWindow()
-            manager.getLatinIMEForDebug().requestHideSelf(0)
+            manager.getLifecycleScope().launch(Dispatchers.Main) {
+                manager.closeActionWindow()
+                delay(50)
+                manager.getLatinIMEForDebug().requestHideSelf(0)
+            }
         }
     }
 
@@ -882,25 +911,29 @@ private class VoiceInputBottomBarWindow(
 
     override fun finished(result: String) {
         wasFinished = true
-        isListening.value = false
-        statusText.value = "Done"
+        manager.getLifecycleScope().launch(Dispatchers.Main) {
+            isListening.value = false
+            statusText.value = "Done"
+            finishRequested = false
 
-        val transaction = inputTransaction ?: run {
-            val t = manager.createInputTransaction()
-            inputTransaction = t
-            t
-        }
-        val sanitized = ModelOutputSanitizer.sanitize(result, transaction.textContext, manager.isCapsLocked())
-        transaction.commit(sanitized)
-        inputTransaction = null
-        val clipboardManager = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-        val clipData = ClipData.newPlainText(context.getString(R.string.action_voice_input_title), sanitized)
-        clipboardManager.setPrimaryClip(clipData)
-        manager.announce(result)
-        if (closeAfterFinish) {
-            closeAfterFinish = false
-            manager.closeActionWindow()
-            manager.getLatinIMEForDebug().requestHideSelf(0)
+            val transaction = inputTransaction ?: run {
+                val t = manager.createInputTransaction()
+                inputTransaction = t
+                t
+            }
+            val sanitized = ModelOutputSanitizer.sanitize(result, transaction.textContext, manager.isCapsLocked())
+            transaction.commit(sanitized)
+            inputTransaction = null
+            val clipboardManager = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+            val clipData = ClipData.newPlainText(context.getString(R.string.action_voice_input_title), sanitized)
+            clipboardManager.setPrimaryClip(clipData)
+            manager.announce(result)
+            if (closeAfterFinish) {
+                closeAfterFinish = false
+                manager.closeActionWindow()
+                delay(50)
+                manager.getLatinIMEForDebug().requestHideSelf(0)
+            }
         }
     }
 

--- a/java/src/org/futo/inputmethod/latin/uix/actions/VoiceInputAction.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/VoiceInputAction.kt
@@ -224,6 +224,8 @@ private class VoiceInputActionWindow(
 
     private var recognizerView: MutableState<RecognizerView?> = mutableStateOf(null)
     private var modelException: MutableState<ModelDoesNotExistException?> = mutableStateOf(null)
+    private var isListening = false
+    private var closeAfterFinish = false
 
     private val initJob = manager.getLifecycleScope().launch {
         yield()
@@ -288,6 +290,11 @@ private class VoiceInputActionWindow(
     }
 
     override fun close(): CloseResult {
+        if (isListening) {
+            closeAfterFinish = true
+            recognizerView.value?.finish()
+            return CloseResult.PreventClosing
+        }
         inputTransaction.cancel()
         runBlocking { initJob.cancelAndJoin() }
         recognizerView.value?.cancel()
@@ -305,12 +312,19 @@ private class VoiceInputActionWindow(
             }
             inputTransaction.cancel()
         }
+        isListening = false
+        if (closeAfterFinish) {
+            closeAfterFinish = false
+            manager.closeActionWindow()
+            manager.getLatinIMEForDebug().requestHideSelf(0)
+        }
     }
 
     override fun recordingStarted(device: MicrophoneDeviceState) {
         if (shouldPlaySounds) {
             state.soundPlayer.playStartSound()
         }
+        isListening = true
 
         // Only set the setting if bluetooth is available, else it would reset the setting
         // every time it's used without a bluetooth device connected.
@@ -325,6 +339,7 @@ private class VoiceInputActionWindow(
         wasFinished = true
 
         manager.getLifecycleScope().launch(Dispatchers.Main) {
+            isListening = false
             val sanitized = ModelOutputSanitizer.sanitize(result, inputTransaction.textContext, manager.isCapsLocked())
             inputTransaction.commit(sanitized)
             val clipboardManager = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
@@ -332,6 +347,10 @@ private class VoiceInputActionWindow(
             clipboardManager.setPrimaryClip(clipData)
             manager.announce(result)
             manager.closeActionWindow()
+            if (closeAfterFinish) {
+                closeAfterFinish = false
+                manager.getLatinIMEForDebug().requestHideSelf(0)
+            }
         }
     }
 
@@ -442,6 +461,7 @@ private class VoiceInputBottomBarWindow(
 
     private var recognizerView: MutableState<RecognizerView?> = mutableStateOf(null)
     private var modelException: MutableState<ModelDoesNotExistException?> = mutableStateOf(null)
+    private var closeAfterFinish = false
 
     private val initJob = manager.getLifecycleScope().launch {
         yield()
@@ -806,6 +826,12 @@ private class VoiceInputBottomBarWindow(
     }
 
     override fun close(): CloseResult {
+        if (isListening.value) {
+            closeAfterFinish = true
+            statusText.value = "Stopping…"
+            recognizerView.value?.finish()
+            return CloseResult.PreventClosing
+        }
         inputTransaction?.cancel()
         inputTransaction = null
         runBlocking { initJob.cancelAndJoin() }
@@ -827,6 +853,11 @@ private class VoiceInputBottomBarWindow(
         }
         isListening.value = false
         statusText.value = "Cancelled"
+        if (closeAfterFinish) {
+            closeAfterFinish = false
+            manager.closeActionWindow()
+            manager.getLatinIMEForDebug().requestHideSelf(0)
+        }
     }
 
     override fun recordingStarted(device: MicrophoneDeviceState) {
@@ -866,6 +897,11 @@ private class VoiceInputBottomBarWindow(
         val clipData = ClipData.newPlainText(context.getString(R.string.action_voice_input_title), sanitized)
         clipboardManager.setPrimaryClip(clipData)
         manager.announce(result)
+        if (closeAfterFinish) {
+            closeAfterFinish = false
+            manager.closeActionWindow()
+            manager.getLatinIMEForDebug().requestHideSelf(0)
+        }
     }
 
     override fun partialResult(result: String) {


### PR DESCRIPTION
### Motivation
- Ensure that when the user presses back while voice recognition is active, the recognizer finishes, its result is committed to the editor, and then the action window and keyboard close.
- Prevent dropping or cancelling an in-progress dictation when the window is closed via back.
- Keep UX consistent between the full-screen voice input and the bottom-bar (floating) voice input UI.

### Description
- Implemented deferred-close behavior in `VoiceInputAction.kt` (both `VoiceInputActionWindow` and `VoiceInputBottomBarWindow`):
  - Added `closeAfterFinish` flag and `isListening` state to track in-progress recognition.
  - `close()` now, when recognition is active, requests the recognizer to `finish()` and returns `CloseResult.PreventClosing` to defer closing until the recognition completes.
  - On `finished(...)` the transcription is sanitized and committed, clipboard is updated, the action window is closed, and if a back-triggered close was requested the keyboard is hidden via `manager.getLatinIMEForDebug().requestHideSelf(0)`.
  - On `cancelled()` if a deferred close was pending we close the action window and hide the keyboard.
- Changes are localized to `java/src/org/futo/inputmethod/latin/uix/actions/VoiceInputAction.kt` and apply to both full and bottom-bar voice input flows.

### Testing
- No automated tests were executed for this change.
- Manual behavioral testing is recommended: open voice input (full and bottom-bar modes), start speaking, press back while recording, and verify the recognition finishes, result is inserted, and the keyboard closes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69459790efc48327a6429fe4aa3709e6)