### PR TITLE
Use system prompt in local transcription

### DIFF
--- a/java/src/org/futo/inputmethod/latin/uix/actions/VoiceInputAction.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/VoiceInputAction.kt
@@ -207,7 +207,8 @@ private class VoiceInputActionWindow(
             decodingConfiguration = DecodingConfiguration(
                 glossary = glossary,
                 languages = allowedLanguages,
-                suppressSymbols = disallowSymbols
+                suppressSymbols = disallowSymbols,
+                systemPrompt = groqSystemPrompt
             ),
             recordingConfiguration = RecordingSettings(
                 preferBluetoothMic = useBluetoothAudio,
@@ -425,7 +426,8 @@ private class VoiceInputBottomBarWindow(
             decodingConfiguration = DecodingConfiguration(
                 glossary = state.userDictionaryObserver.getWords(locales).map { it.word },
                 languages = allowedLanguages,
-                suppressSymbols = disallowSymbols
+                suppressSymbols = disallowSymbols,
+                systemPrompt = groqSystemPrompt
             ),
             recordingConfiguration = RecordingSettings(
                 preferBluetoothMic = useBluetoothAudio,

--- a/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/whisper/MultiModelRunner.kt
+++ b/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/whisper/MultiModelRunner.kt
@@ -23,7 +23,8 @@ data class MultiModelRunConfiguration(
 data class DecodingConfiguration(
     val glossary: List<String>,
     val languages: Set<Language>,
-    val suppressSymbols: Boolean
+    val suppressSymbols: Boolean,
+    val systemPrompt: String = ""
 )
 
 class MultiModelRunner(
@@ -65,12 +66,16 @@ class MultiModelRunner(
         } else {
             ""
         }
+        val systemPrompt = decodingConfiguration.systemPrompt.trim()
+        val prompt = listOf(glossary, systemPrompt)
+            .filter { it.isNotBlank() }
+            .joinToString(separator = "\n")
 
         val result = try {
             callback.updateStatus(InferenceState.Encoding)
             primaryModel.infer(
                 samples = samples,
-                prompt = glossary,
+                prompt = prompt,
                 languages = allowedLanguages,
                 bailLanguages = bailLanguages,
                 decodingMode = DecodingMode.BeamSearch5,
@@ -88,7 +93,7 @@ class MultiModelRunner(
 
             specificModel.infer(
                 samples = samples,
-                prompt = glossary,
+                prompt = prompt,
                 languages = arrayOf(e.language),
                 bailLanguages = arrayOf(),
                 decodingMode = DecodingMode.BeamSearch5,


### PR DESCRIPTION
### Motivation
- Remote Groq transcription already accepts a system prompt, but the local Whisper-based path only used the `glossary` for hints.
- Reuse the existing system prompt setting for local transcription to provide consistent guidance between remote and local paths.
- Keep behaviour simple by appending the system prompt to the existing glossary prompt (rather than introducing a new prompt mechanism).

### Description
- Added a `systemPrompt` field to `DecodingConfiguration` (`voiceinput-shared/src/main/java/org/futo/voiceinput/shared/whisper/MultiModelRunner.kt`).
- Combine the glossary and `systemPrompt` into a single `prompt` string and pass it to local inference via `Model.infer` (applies to both primary and language-specific model branches).
- Wired the UI/settings layer to propagate the Groq system prompt into the local decoding configuration by setting `systemPrompt = groqSystemPrompt` in `VoiceInputAction.kt` (both window variants).
- Modified files: `voiceinput-shared/.../whisper/MultiModelRunner.kt` and `java/src/.../VoiceInputAction.kt`.

### Testing
- No automated tests were executed for this change.
- Basic repository actions performed: staging and committing the two modified files (`Use system prompt in local transcription`).
- Recommend running the app and performing voice transcription flows (with and without Groq enabled) and existing unit/integration tests (`./gradlew test` / relevant Android instrumentation tests) as next steps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694596f493888327aa46973382fbd380)