### PR TITLE
Scope clipboard-search focus to clipboard search field to fix emoji search input

### DIFF
--- a/java/src/org/futo/inputmethod/latin/uix/ActionTextEdit.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/ActionTextEdit.kt
@@ -309,7 +309,8 @@ fun ActionTextEditor(
     textSize: TextUnit = 16.sp,
     typeface: Typeface? = null,
     autocorrect: Boolean = false,
-    autofocus: Boolean = true
+    autofocus: Boolean = true,
+    clipboardSearchFocus: Boolean = false
 ) {
     val manager = if(!LocalInspectionMode.current) LocalManager.current else null
     GenericEditTextCompose(
@@ -322,11 +323,15 @@ fun ActionTextEditor(
         modifier = Modifier.fillMaxSize(),
         onOverride = { ic, ed ->
             manager!!.overrideInputConnection(ic, ed)
-            manager.setClipboardSearchFocus(true)
+            if (clipboardSearchFocus) {
+                manager.setClipboardSearchFocus(true)
+            }
         },
         onUnoverride = {
             manager!!.unsetInputConnection()
-            manager.setClipboardSearchFocus(false)
+            if (clipboardSearchFocus) {
+                manager.setClipboardSearchFocus(false)
+            }
         },
         autofocus = autofocus,
         isInsideIme = true

--- a/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryComposables.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryComposables.kt
@@ -460,7 +460,10 @@ fun ClipboardHistoryWindowTitleBar(
                     contentAlignment = Alignment.CenterStart
                 ) {
                     // Automatically focus the search field just like the emoji search bar
-                    ActionTextEditor(text = searchText)
+                    ActionTextEditor(
+                        text = searchText,
+                        clipboardSearchFocus = true
+                    )
                 }
             }
 


### PR DESCRIPTION
### Motivation
- Emoji search input was being affected by global clipboard-search focus handling that hijacked the input connection and prevented normal emoji search behavior.
- The intent is to keep clipboard search focus tracking only for the clipboard history search field so other action windows (like emoji) use normal input routing.

### Description
- Added a `clipboardSearchFocus: Boolean` parameter to `ActionTextEditor` and only call `manager.setClipboardSearchFocus(true/false)` when this flag is set.
- Updated `ClipboardHistoryComposables.kt` to pass `clipboardSearchFocus = true` for the clipboard history search field so it continues to get the special focus behavior.
- Key symbols changed: `ActionTextEditor`, `setClipboardSearchFocus`, and the clipboard search `ActionTextEditor` invocation in `ClipboardHistoryComposables.kt`.
- Changes applied to `java/src/org/futo/inputmethod/latin/uix/ActionTextEdit.kt` and `java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryComposables.kt` and committed.

### Testing
- No automated tests were run on these changes.
- Changes were committed successfully (`Fix emoji search focus handling`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d08ca384883278256e7b48f114eae)