### PR TITLE
Fix emoji search focus handling

### DIFF
--- a/java/src/org/futo/inputmethod/latin/uix/ActionTextEdit.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/ActionTextEdit.kt
@@ -309,7 +309,8 @@ fun ActionTextEditor(
     textSize: TextUnit = 16.sp,
     typeface: Typeface? = null,
     autocorrect: Boolean = false,
-    autofocus: Boolean = true
+    autofocus: Boolean = true,
+    clipboardSearchFocus: Boolean = false
 ) {
     val manager = if(!LocalInspectionMode.current) LocalManager.current else null
     GenericEditTextCompose(
@@ -322,11 +323,15 @@ fun ActionTextEditor(
         modifier = Modifier.fillMaxSize(),
         onOverride = { ic, ed ->
             manager!!.overrideInputConnection(ic, ed)
-            manager.setClipboardSearchFocus(true)
+            if (clipboardSearchFocus) {
+                manager.setClipboardSearchFocus(true)
+            }
         },
         onUnoverride = {
             manager!!.unsetInputConnection()
-            manager.setClipboardSearchFocus(false)
+            if (clipboardSearchFocus) {
+                manager.setClipboardSearchFocus(false)
+            }
         },
         autofocus = autofocus,
         isInsideIme = true

--- a/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryComposables.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryComposables.kt
@@ -460,7 +460,7 @@ fun ClipboardHistoryWindowTitleBar(
                     contentAlignment = Alignment.CenterStart
                 ) {
                     // Automatically focus the search field just like the emoji search bar
-                    ActionTextEditor(text = searchText)
+                    ActionTextEditor(text = searchText, clipboardSearchFocus = true)
                 }
             }
 

--- a/java/src/org/futo/inputmethod/latin/uix/actions/EmojiAction.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/EmojiAction.kt
@@ -1026,7 +1026,7 @@ val EmojiAction = Action(
                                 modifier = Modifier.padding(8.dp),
                                 contentAlignment = Alignment.CenterStart
                             ) {
-                                ActionTextEditor(text = searchText)
+                                ActionTextEditor(text = searchText, clipboardSearchFocus = true)
                             }
                         }
                     }


### PR DESCRIPTION
### Motivation
- The emoji search field and clipboard search needed to correctly request focus into the IME’s search input so typing/backspace are routed to the in-IME search field instead of the host app.
- Previously `ActionTextEditor` unconditionally toggled clipboard-search focus which caused unrelated action editors to modify focus state and prevented the emoji search box from working reliably.

### Description
- Added a new boolean parameter `clipboardSearchFocus` to `ActionTextEditor` to control whether the editor should toggle the IME clipboard/search focus when it overrides/unsets the input connection.
- Guarded calls to `manager.setClipboardSearchFocus(true/false)` inside `ActionTextEditor` so they only run when `clipboardSearchFocus` is enabled.
- Enabled the new `clipboardSearchFocus = true` flag where appropriate by updating `EmojiAction.kt` and `ClipboardHistoryComposables.kt` so the emoji and clipboard search fields request the correct focus.

### Testing
- No automated tests were run as part of this change.
- Verified code compiles locally via the commit process (no test suite executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d090c990c8327bb9915246817a705)