### PR TITLE
Scope clipboard search focus to clipboard history search field

### DIFF
--- a/java/src/org/futo/inputmethod/latin/uix/ActionTextEdit.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/ActionTextEdit.kt
@@ -309,7 +309,8 @@ fun ActionTextEditor(
     textSize: TextUnit = 16.sp,
     typeface: Typeface? = null,
     autocorrect: Boolean = false,
-    autofocus: Boolean = true
+    autofocus: Boolean = true,
+    clipboardSearchFocus: Boolean = false
 ) {
     val manager = if(!LocalInspectionMode.current) LocalManager.current else null
     GenericEditTextCompose(
@@ -322,11 +323,15 @@ fun ActionTextEditor(
         modifier = Modifier.fillMaxSize(),
         onOverride = { ic, ed ->
             manager!!.overrideInputConnection(ic, ed)
-            manager.setClipboardSearchFocus(true)
+            if (clipboardSearchFocus) {
+                manager.setClipboardSearchFocus(true)
+            }
         },
         onUnoverride = {
             manager!!.unsetInputConnection()
-            manager.setClipboardSearchFocus(false)
+            if (clipboardSearchFocus) {
+                manager.setClipboardSearchFocus(false)
+            }
         },
         autofocus = autofocus,
         isInsideIme = true

--- a/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryComposables.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryComposables.kt
@@ -460,7 +460,7 @@ fun ClipboardHistoryWindowTitleBar(
                     contentAlignment = Alignment.CenterStart
                 ) {
                     // Automatically focus the search field just like the emoji search bar
-                    ActionTextEditor(text = searchText)
+                    ActionTextEditor(text = searchText, clipboardSearchFocus = true)
                 }
             }
 


### PR DESCRIPTION
### Motivation
- Emoji search field input was being incorrectly routed to the clipboard search handling, preventing text input from reaching the emoji search box.
- The input-connection override in `ActionTextEditor` unconditionally toggled clipboard search focus, affecting unrelated action windows.

### Description
- Add an optional `clipboardSearchFocus: Boolean` parameter to `ActionTextEditor` with a default of `false` so focus behavior can be opt-in.
- Only call `manager.setClipboardSearchFocus(true/false)` when `clipboardSearchFocus` is `true` inside `ActionTextEditor`.
- Enable `clipboardSearchFocus = true` only for the clipboard history search field by updating `ClipboardHistoryComposables.kt` to call `ActionTextEditor(text = searchText, clipboardSearchFocus = true)`.
- Modified files: `java/src/org/futo/inputmethod/latin/uix/ActionTextEdit.kt` and `java/src/org/futo/inputmethod/latin/uix/actions/ClipboardHistoryComposables.kt`.

### Testing
- No automated tests were executed as part of this change.
- The change is limited to input focus routing and is implemented as a backwards-compatible opt-in flag for `ActionTextEditor`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dda2056908327bf5aa0b77e77db05)