### PR TITLE
Add recording channel selection to Voice Input settings

### DIFF
--- a/java/res/values/strings-uix.xml
+++ b/java/res/values/strings-uix.xml
@@ -535,6 +535,12 @@
     <string name="voice_input_settings_use_personal_dict_subtitle">Whether or not to use the personal dictionary for voice input</string>
     <string name="voice_input_settings_use_bluetooth_mic">Prefer Bluetooth Mic</string>
     <string name="voice_input_settings_use_bluetooth_mic_subtitle">There may be extra delay to recording starting as Bluetooth SCO connection must be negotiated</string>
+    <string name="voice_input_settings_recording_channel">Recording channel</string>
+    <string name="voice_input_settings_recording_channel_subtitle">Choose which audio channel to send for voice recognition</string>
+    <string name="voice_input_settings_recording_channel_mono">Mono (default)</string>
+    <string name="voice_input_settings_recording_channel_left">Left channel</string>
+    <string name="voice_input_settings_recording_channel_right">Right channel</string>
+    <string name="voice_input_settings_recording_channel_stereo_mix">Stereo mix</string>
     <string name="voice_input_settings_audio_focus">Audio Focus</string>
     <string name="voice_input_settings_audio_focus_subtitle">Pause videos/music when voice input is activated</string>
     <string name="voice_input_settings_suppress_symbols">Suppress symbols</string>

--- a/java/src/org/futo/inputmethod/latin/uix/VoiceInputSettingKeys.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/VoiceInputSettingKeys.kt
@@ -35,6 +35,11 @@ val PREFER_BLUETOOTH = SettingsKey(
     default = false
 )
 
+val VOICE_INPUT_RECORDING_CHANNEL = SettingsKey(
+    key = intPreferencesKey("voice_input_recording_channel"),
+    default = 0
+)
+
 val CAN_EXPAND_SPACE = SettingsKey(
     key = booleanPreferencesKey("can_expand_space"),
     default = true

--- a/java/src/org/futo/inputmethod/latin/uix/actions/VoiceInputAction.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/VoiceInputAction.kt
@@ -87,6 +87,7 @@ import org.futo.inputmethod.latin.uix.GROQ_VOICE_API_KEY
 import org.futo.inputmethod.latin.uix.GROQ_VOICE_MODEL
 import org.futo.inputmethod.latin.uix.GROQ_VOICE_SYSTEM_PROMPT
 import org.futo.inputmethod.latin.uix.USE_GPU_OFFLOAD
+import org.futo.inputmethod.latin.uix.VOICE_INPUT_RECORDING_CHANNEL
 import org.futo.inputmethod.latin.uix.VOICE_INPUT_BOTTOM_BAR_MODE
 import org.futo.inputmethod.latin.uix.LocalKeyboardScheme
 import org.futo.inputmethod.latin.uix.getSetting
@@ -99,6 +100,7 @@ import org.futo.voiceinput.shared.ModelDoesNotExistException
 import org.futo.voiceinput.shared.RecognizerView
 import org.futo.voiceinput.shared.RecognizerViewListener
 import org.futo.voiceinput.shared.RecognizerViewSettings
+import org.futo.voiceinput.shared.RecordingChannel
 import org.futo.voiceinput.shared.RecordingSettings
 import org.futo.voiceinput.shared.SoundPlayer
 import org.futo.voiceinput.shared.types.Language
@@ -183,6 +185,7 @@ private class VoiceInputActionWindow(
         val groqModel = context.getSetting(GROQ_VOICE_MODEL)
         val useGpu = context.getSetting(USE_GPU_OFFLOAD)
         val groqSystemPrompt = context.getSetting(GROQ_VOICE_SYSTEM_PROMPT)
+        val recordingChannel = RecordingChannel.fromId(context.getSetting(VOICE_INPUT_RECORDING_CHANNEL))
 
         state.modelManager.useGpu = useGpu
 
@@ -214,7 +217,8 @@ private class VoiceInputActionWindow(
                 preferBluetoothMic = useBluetoothAudio,
                 requestAudioFocus = requestAudioFocus,
                 canExpandSpace = canExpandSpace,
-                useVADAutoStop = useVAD
+                useVADAutoStop = useVAD,
+                recordingChannel = recordingChannel
             ),
             groqApiKey = if(useGroq) groqKey else "",
             groqModel = groqModel,
@@ -406,6 +410,7 @@ private class VoiceInputBottomBarWindow(
         val groqModel = context.getSetting(GROQ_VOICE_MODEL)
         val useGpu = context.getSetting(USE_GPU_OFFLOAD)
         val groqSystemPrompt = context.getSetting(GROQ_VOICE_SYSTEM_PROMPT)
+        val recordingChannel = RecordingChannel.fromId(context.getSetting(VOICE_INPUT_RECORDING_CHANNEL))
 
         state.modelManager.useGpu = useGpu
 
@@ -433,7 +438,8 @@ private class VoiceInputBottomBarWindow(
                 preferBluetoothMic = useBluetoothAudio,
                 requestAudioFocus = requestAudioFocus,
                 canExpandSpace = canExpandSpace,
-                useVADAutoStop = useVAD
+                useVADAutoStop = useVAD,
+                recordingChannel = recordingChannel
             ),
             groqApiKey = if(useGroq) groqKey else "",
             groqModel = groqModel,

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/VoiceInput.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/VoiceInput.kt
@@ -1,7 +1,7 @@
 package org.futo.inputmethod.latin.uix.settings.pages
 
-import android.content.Intent
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
 import org.futo.inputmethod.latin.R
 import org.futo.inputmethod.latin.uix.AUDIO_FOCUS
 import org.futo.inputmethod.latin.uix.CAN_EXPAND_SPACE
@@ -11,17 +11,22 @@ import org.futo.inputmethod.latin.uix.PREFER_BLUETOOTH
 import org.futo.inputmethod.latin.uix.USE_PERSONAL_DICT
 import org.futo.inputmethod.latin.uix.USE_SYSTEM_VOICE_INPUT
 import org.futo.inputmethod.latin.uix.USE_VAD_AUTOSTOP
-import org.futo.inputmethod.latin.uix.VERBOSE_PROGRESS
 import org.futo.inputmethod.latin.uix.USE_GROQ_WHISPER
 import org.futo.inputmethod.latin.uix.GROQ_VOICE_API_KEY
 import org.futo.inputmethod.latin.uix.USE_GPU_OFFLOAD
 import org.futo.inputmethod.latin.uix.START_VOICE_ON_OPEN
 import org.futo.inputmethod.latin.uix.VOICE_INPUT_BOTTOM_BAR_MODE
+import org.futo.inputmethod.latin.uix.VOICE_INPUT_RECORDING_CHANNEL
+import org.futo.inputmethod.latin.uix.settings.DropDownPicker
 import org.futo.inputmethod.latin.uix.settings.NavigationItemStyle
+import org.futo.inputmethod.latin.uix.settings.SettingItem
+import org.futo.inputmethod.latin.uix.settings.UserSetting
 import org.futo.inputmethod.latin.uix.settings.UserSettingsMenu
+import org.futo.inputmethod.latin.uix.settings.useDataStore
 import org.futo.inputmethod.latin.uix.settings.useDataStoreValue
 import org.futo.inputmethod.latin.uix.settings.userSettingNavigationItem
 import org.futo.inputmethod.latin.uix.settings.userSettingToggleDataStore
+import org.futo.voiceinput.shared.RecordingChannel
 
 private val visibilityCheckNotSystemVoiceInput = @Composable {
     useDataStoreValue(USE_SYSTEM_VOICE_INPUT) == false
@@ -62,6 +67,40 @@ val VoiceInputMenu = UserSettingsMenu(
             title = R.string.voice_input_settings_use_bluetooth_mic,
             subtitle = R.string.voice_input_settings_use_bluetooth_mic_subtitle,
             setting = PREFER_BLUETOOTH
+        ).copy(visibilityCheck = visibilityCheckNotSystemVoiceInput),
+
+        UserSetting(
+            name = R.string.voice_input_settings_recording_channel,
+            subtitle = R.string.voice_input_settings_recording_channel_subtitle,
+            component = {
+                val recordingChannelSetting = useDataStore(VOICE_INPUT_RECORDING_CHANNEL)
+                val selectedChannel = RecordingChannel.fromId(recordingChannelSetting.value)
+                val channelOptions = listOf(
+                    RecordingChannel.MONO,
+                    RecordingChannel.LEFT,
+                    RecordingChannel.RIGHT,
+                    RecordingChannel.STEREO_MIX
+                )
+                SettingItem(
+                    title = stringResource(R.string.voice_input_settings_recording_channel),
+                    subtitle = stringResource(R.string.voice_input_settings_recording_channel_subtitle),
+                    subcontent = {
+                        DropDownPicker(
+                            options = channelOptions,
+                            selection = selectedChannel,
+                            onSet = { channel -> recordingChannelSetting.setValue(channel.id) },
+                            getDisplayName = { channel ->
+                                when (channel) {
+                                    RecordingChannel.MONO -> stringResource(R.string.voice_input_settings_recording_channel_mono)
+                                    RecordingChannel.LEFT -> stringResource(R.string.voice_input_settings_recording_channel_left)
+                                    RecordingChannel.RIGHT -> stringResource(R.string.voice_input_settings_recording_channel_right)
+                                    RecordingChannel.STEREO_MIX -> stringResource(R.string.voice_input_settings_recording_channel_stereo_mix)
+                                }
+                            }
+                        )
+                    }
+                ) {}
+            }
         ).copy(visibilityCheck = visibilityCheckNotSystemVoiceInput),
 
         userSettingToggleDataStore(

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/VoiceInput.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/VoiceInput.kt
@@ -1,6 +1,7 @@
 package org.futo.inputmethod.latin.uix.settings.pages
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import org.futo.inputmethod.latin.R
 import org.futo.inputmethod.latin.uix.AUDIO_FOCUS
@@ -73,6 +74,7 @@ val VoiceInputMenu = UserSettingsMenu(
             name = R.string.voice_input_settings_recording_channel,
             subtitle = R.string.voice_input_settings_recording_channel_subtitle,
             component = {
+                val context = LocalContext.current
                 val recordingChannelSetting = useDataStore(VOICE_INPUT_RECORDING_CHANNEL)
                 val selectedChannel = RecordingChannel.fromId(recordingChannelSetting.value)
                 val channelOptions = listOf(
@@ -80,6 +82,12 @@ val VoiceInputMenu = UserSettingsMenu(
                     RecordingChannel.LEFT,
                     RecordingChannel.RIGHT,
                     RecordingChannel.STEREO_MIX
+                )
+                val channelLabels = mapOf(
+                    RecordingChannel.MONO to R.string.voice_input_settings_recording_channel_mono,
+                    RecordingChannel.LEFT to R.string.voice_input_settings_recording_channel_left,
+                    RecordingChannel.RIGHT to R.string.voice_input_settings_recording_channel_right,
+                    RecordingChannel.STEREO_MIX to R.string.voice_input_settings_recording_channel_stereo_mix
                 )
                 SettingItem(
                     title = stringResource(R.string.voice_input_settings_recording_channel),
@@ -90,12 +98,7 @@ val VoiceInputMenu = UserSettingsMenu(
                             selection = selectedChannel,
                             onSet = { channel -> recordingChannelSetting.setValue(channel.id) },
                             getDisplayName = { channel ->
-                                when (channel) {
-                                    RecordingChannel.MONO -> stringResource(R.string.voice_input_settings_recording_channel_mono)
-                                    RecordingChannel.LEFT -> stringResource(R.string.voice_input_settings_recording_channel_left)
-                                    RecordingChannel.RIGHT -> stringResource(R.string.voice_input_settings_recording_channel_right)
-                                    RecordingChannel.STEREO_MIX -> stringResource(R.string.voice_input_settings_recording_channel_stereo_mix)
-                                }
+                                channelLabels[channel]?.let(context::getString) ?: channel.name
                             }
                         )
                     }

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/VoiceInput.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/VoiceInput.kt
@@ -1,8 +1,13 @@
 package org.futo.inputmethod.latin.uix.settings.pages
 
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.material3.Text
 import org.futo.inputmethod.latin.R
 import org.futo.inputmethod.latin.uix.AUDIO_FOCUS
 import org.futo.inputmethod.latin.uix.CAN_EXPAND_SPACE
@@ -21,6 +26,7 @@ import org.futo.inputmethod.latin.uix.VOICE_INPUT_RECORDING_CHANNEL
 import org.futo.inputmethod.latin.uix.settings.DropDownPicker
 import org.futo.inputmethod.latin.uix.settings.NavigationItemStyle
 import org.futo.inputmethod.latin.uix.settings.SettingItem
+import org.futo.inputmethod.latin.uix.settings.Typography
 import org.futo.inputmethod.latin.uix.settings.UserSetting
 import org.futo.inputmethod.latin.uix.settings.UserSettingsMenu
 import org.futo.inputmethod.latin.uix.settings.useDataStore
@@ -91,8 +97,12 @@ val VoiceInputMenu = UserSettingsMenu(
                 )
                 SettingItem(
                     title = stringResource(R.string.voice_input_settings_recording_channel),
-                    subtitle = stringResource(R.string.voice_input_settings_recording_channel_subtitle),
                     subcontent = {
+                        Text(
+                            text = stringResource(R.string.voice_input_settings_recording_channel_subtitle),
+                            style = Typography.SmallMl
+                        )
+                        Spacer(Modifier.height(6.dp))
                         DropDownPicker(
                             options = channelOptions,
                             selection = selectedChannel,

--- a/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/AudioRecognizer.kt
+++ b/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/AudioRecognizer.kt
@@ -80,11 +80,25 @@ private fun getRecordingDeviceKind(type: Int): String {
     }
 }
 
+enum class RecordingChannel(val id: Int, val channelCount: Int) {
+    MONO(0, 1),
+    LEFT(1, 2),
+    RIGHT(2, 2),
+    STEREO_MIX(3, 2);
+
+    companion object {
+        fun fromId(id: Int): RecordingChannel {
+            return entries.firstOrNull { it.id == id } ?: MONO
+        }
+    }
+}
+
 data class RecordingSettings(
     val preferBluetoothMic: Boolean,
     val requestAudioFocus: Boolean,
     val canExpandSpace: Boolean,
-    val useVADAutoStop: Boolean
+    val useVADAutoStop: Boolean,
+    val recordingChannel: RecordingChannel
 )
 
 data class AudioRecognizerSettings(
@@ -118,6 +132,8 @@ class AudioRecognizer(
 
     private val canExpandSpace = settings.recordingConfiguration.canExpandSpace
     private val useVAD = settings.recordingConfiguration.useVADAutoStop
+    private val recordingChannel = settings.recordingConfiguration.recordingChannel
+    private val inputChannelCount = recordingChannel.channelCount
 
     private var floatSamples: FloatBuffer = FloatBuffer.allocate(16000 * 30)
     private var recorderJob: Job? = null
@@ -127,6 +143,52 @@ class AudioRecognizer(
     private var focusRequest: AudioFocusRequest? = null
 
     private var communicationDevice = "unknown"
+
+    private fun getInputChannelConfig(): Int {
+        return if (recordingChannel == RecordingChannel.MONO) {
+            AudioFormat.CHANNEL_IN_MONO
+        } else {
+            AudioFormat.CHANNEL_IN_STEREO
+        }
+    }
+
+    private fun extractMonoSamples(
+        source: ShortArray,
+        nRead: Int,
+        destination: ShortArray
+    ): Int {
+        return if (inputChannelCount == 1) {
+            System.arraycopy(source, 0, destination, 0, nRead)
+            nRead
+        } else {
+            val frames = nRead / inputChannelCount
+            when (recordingChannel) {
+                RecordingChannel.LEFT -> {
+                    for (i in 0 until frames) {
+                        destination[i] = source[i * 2]
+                    }
+                }
+                RecordingChannel.RIGHT -> {
+                    for (i in 0 until frames) {
+                        destination[i] = source[i * 2 + 1]
+                    }
+                }
+                RecordingChannel.STEREO_MIX -> {
+                    for (i in 0 until frames) {
+                        val left = source[i * 2].toInt()
+                        val right = source[i * 2 + 1].toInt()
+                        destination[i] = ((left + right) / 2).toShort()
+                    }
+                }
+                RecordingChannel.MONO -> {
+                    for (i in 0 until frames) {
+                        destination[i] = source[i * 2]
+                    }
+                }
+            }
+            frames
+        }
+    }
 
     private fun focusAudio() {
         unfocusAudio()
@@ -296,9 +358,9 @@ class AudioRecognizer(
         val recorder = AudioRecord(
             MediaRecorder.AudioSource.VOICE_RECOGNITION,
             16000,
-            AudioFormat.CHANNEL_IN_MONO,
+            getInputChannelConfig(),
             AudioFormat.ENCODING_PCM_16BIT,
-            16000 * 2 * 5
+            16000 * 2 * 5 * inputChannelCount
         )
 
         this.recorder = recorder
@@ -343,15 +405,19 @@ class AudioRecognizer(
         var numConsecutiveNonSpeech = 0
         var numConsecutiveSpeech = 0
 
-        val samples = ShortArray(1600)
+        val frameSamples = 1600
+        val readSamples = frameSamples * inputChannelCount
+        val samples = ShortArray(readSamples)
+        val monoSamples = ShortArray(frameSamples)
 
         while (isRecording) {
             yield()
-            val nRead = recorder.read(samples, 0, 1600, AudioRecord.READ_BLOCKING)
+            val nRead = recorder.read(samples, 0, readSamples, AudioRecord.READ_BLOCKING)
             if (nRead <= 0) break
             yield()
 
-            var isRunningOutOfSpace = (floatSamples.remaining() < nRead.coerceAtLeast(1600)) && !expandSpaceIfAllowed()
+            val monoRead = extractMonoSamples(samples, nRead, monoSamples)
+            var isRunningOutOfSpace = (floatSamples.remaining() < monoRead.coerceAtLeast(frameSamples)) && !expandSpaceIfAllowed()
 
             val hasNotTalkedRecently = hasTalked && (numConsecutiveNonSpeech > 66) && useVAD
             if (isRunningOutOfSpace || hasNotTalkedRecently) {
@@ -364,7 +430,7 @@ class AudioRecognizer(
 
             // Run VAD
             if(useVAD && vad != null) {
-                var remainingSamples = nRead
+                var remainingSamples = monoRead
                 var offset = 0
                 while (remainingSamples > 0) {
                     if (!vadSampleBuffer.hasRemaining()) {
@@ -384,7 +450,7 @@ class AudioRecognizer(
                     val samplesToRead = min(min(remainingSamples, 480), vadSampleBuffer.remaining())
                     for (i in 0 until samplesToRead) {
                         vadSampleBuffer.put(
-                            samples[offset]
+                            monoSamples[offset]
                         )
                         offset += 1
                         remainingSamples -= 1
@@ -392,7 +458,7 @@ class AudioRecognizer(
                 }
             }
 
-            floatSamples.put(samples.sliceArray(0 until nRead).map { it.toFloat() / Short.MAX_VALUE.toFloat() }.toFloatArray())
+            floatSamples.put(monoSamples.sliceArray(0 until monoRead).map { it.toFloat() / Short.MAX_VALUE.toFloat() }.toFloatArray())
             if(floatSamples.position() >= 16000 * 60) {
                 yield()
                 withContext(Dispatchers.Main) { finish() }
@@ -407,7 +473,12 @@ class AudioRecognizer(
                 numConsecutiveNonSpeech = 0
             }
 
-            val rms = sqrt(samples.sumOf { (it.toFloat() / Short.MAX_VALUE.toFloat()).pow(2).toDouble() } / samples.size).toFloat()
+            var sumSquares = 0.0
+            for (i in 0 until monoRead) {
+                val sample = monoSamples[i].toFloat() / Short.MAX_VALUE.toFloat()
+                sumSquares += (sample * sample).toDouble()
+            }
+            val rms = sqrt(sumSquares / monoRead).toFloat()
 
             if (startSoundPassed && ((rms > 0.01) || (numConsecutiveSpeech > 8))) {
                 hasTalked = true
@@ -444,17 +515,18 @@ class AudioRecognizer(
             while (true) {
                 yield()
                 val nRead2 = recorder.read(
-                    samples, 0, 1600, AudioRecord.READ_NON_BLOCKING
+                    samples, 0, readSamples, AudioRecord.READ_NON_BLOCKING
                 )
                 if (nRead2 > 0) {
-                    if (floatSamples.remaining() < nRead2 && !expandSpaceIfAllowed()) {
+                    val monoRead2 = extractMonoSamples(samples, nRead2, monoSamples)
+                    if (floatSamples.remaining() < monoRead2 && !expandSpaceIfAllowed()) {
                         yield()
                         withContext(Dispatchers.Main) {
                             finish()
                         }
                         break
                     }
-                    floatSamples.put(samples.sliceArray(0 until nRead2).map { it.toFloat() / Short.MAX_VALUE.toFloat() }.toFloatArray())
+                    floatSamples.put(monoSamples.sliceArray(0 until monoRead2).map { it.toFloat() / Short.MAX_VALUE.toFloat() }.toFloatArray())
                     if(floatSamples.position() >= 16000 * 60) {
                         yield()
                         withContext(Dispatchers.Main) { finish() }


### PR DESCRIPTION
### Motivation

- Provide users control over which microphone channel is used for voice recording so downstream processing/recognition can receive the desired channel (mono/left/right/stereo mix).

### Description

- Add `RecordingChannel` enum and extend `RecordingSettings` with a `recordingChannel` field and a `VOICE_INPUT_RECORDING_CHANNEL` persisted setting to store the user choice.
- Wire the new setting into voice input configuration by reading `VOICE_INPUT_RECORDING_CHANNEL` in `VoiceInputAction` and passing the chosen `RecordingChannel` into `RecognizerViewSettings`.
- Add a UI dropdown to the Voice Input settings (`VoiceInput.kt`) with new strings (`strings-uix.xml`) for the channel option and its labels.
- Update the recorder implementation in `AudioRecognizer` to support stereo capture when needed, extract mono samples according to the selected channel (left/right/stereo mix/mono), adjust buffer/read sizes, and compute RMS from the extracted mono samples before feeding downstream.

### Testing

- No automated tests were run for this change (no test runs requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a31335ef88327970463b3c58bcca6)