### PR TITLE
Add voice input channel selection and test-channel recording

### DIFF
--- a/java/res/values/strings-uix.xml
+++ b/java/res/values/strings-uix.xml
@@ -535,6 +535,12 @@
     <string name="voice_input_settings_use_personal_dict_subtitle">Whether or not to use the personal dictionary for voice input</string>
     <string name="voice_input_settings_use_bluetooth_mic">Prefer Bluetooth Mic</string>
     <string name="voice_input_settings_use_bluetooth_mic_subtitle">There may be extra delay to recording starting as Bluetooth SCO connection must be negotiated</string>
+    <string name="voice_input_settings_audio_channel">Audio recording channel</string>
+    <string name="voice_input_settings_audio_channel_subtitle">Choose which audio channel to use for voice input recording</string>
+    <string name="voice_input_settings_audio_channel_default">Default (mono)</string>
+    <string name="voice_input_settings_audio_channel_1">Channel 1</string>
+    <string name="voice_input_settings_audio_channel_2">Channel 2</string>
+    <string name="voice_input_settings_audio_channel_test">Test channels 1 + 2</string>
     <string name="voice_input_settings_audio_focus">Audio Focus</string>
     <string name="voice_input_settings_audio_focus_subtitle">Pause videos/music when voice input is activated</string>
     <string name="voice_input_settings_suppress_symbols">Suppress symbols</string>

--- a/java/src/org/futo/inputmethod/latin/uix/VoiceInputSettingKeys.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/VoiceInputSettingKeys.kt
@@ -104,3 +104,8 @@ val USE_PERSONAL_DICT = SettingsKey(
     key = booleanPreferencesKey("use_personal_dict_voice_input"),
     default = true
 )
+
+val VOICE_INPUT_CHANNEL_MODE = SettingsKey(
+    key = intPreferencesKey("voice_input_channel_mode"),
+    default = 0
+)

--- a/java/src/org/futo/inputmethod/latin/uix/actions/VoiceInputAction.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/VoiceInputAction.kt
@@ -88,6 +88,7 @@ import org.futo.inputmethod.latin.uix.GROQ_VOICE_MODEL
 import org.futo.inputmethod.latin.uix.GROQ_VOICE_SYSTEM_PROMPT
 import org.futo.inputmethod.latin.uix.USE_GPU_OFFLOAD
 import org.futo.inputmethod.latin.uix.VOICE_INPUT_BOTTOM_BAR_MODE
+import org.futo.inputmethod.latin.uix.VOICE_INPUT_CHANNEL_MODE
 import org.futo.inputmethod.latin.uix.LocalKeyboardScheme
 import org.futo.inputmethod.latin.uix.getSetting
 import org.futo.inputmethod.latin.uix.setSetting
@@ -103,6 +104,7 @@ import org.futo.voiceinput.shared.RecordingSettings
 import org.futo.voiceinput.shared.SoundPlayer
 import org.futo.voiceinput.shared.types.Language
 import org.futo.voiceinput.shared.types.ModelLoader
+import org.futo.voiceinput.shared.types.RecordingChannelMode
 import org.futo.voiceinput.shared.types.getLanguageFromWhisperString
 import org.futo.voiceinput.shared.ui.MicrophoneDeviceState
 import org.futo.voiceinput.shared.whisper.DecodingConfiguration
@@ -183,6 +185,7 @@ private class VoiceInputActionWindow(
         val groqModel = context.getSetting(GROQ_VOICE_MODEL)
         val useGpu = context.getSetting(USE_GPU_OFFLOAD)
         val groqSystemPrompt = context.getSetting(GROQ_VOICE_SYSTEM_PROMPT)
+        val channelMode = RecordingChannelMode.fromSetting(context.getSetting(VOICE_INPUT_CHANNEL_MODE))
 
         state.modelManager.useGpu = useGpu
 
@@ -214,7 +217,8 @@ private class VoiceInputActionWindow(
                 preferBluetoothMic = useBluetoothAudio,
                 requestAudioFocus = requestAudioFocus,
                 canExpandSpace = canExpandSpace,
-                useVADAutoStop = useVAD
+                useVADAutoStop = useVAD,
+                channelMode = channelMode
             ),
             groqApiKey = if(useGroq) groqKey else "",
             groqModel = groqModel,
@@ -406,6 +410,7 @@ private class VoiceInputBottomBarWindow(
         val groqModel = context.getSetting(GROQ_VOICE_MODEL)
         val useGpu = context.getSetting(USE_GPU_OFFLOAD)
         val groqSystemPrompt = context.getSetting(GROQ_VOICE_SYSTEM_PROMPT)
+        val channelMode = RecordingChannelMode.fromSetting(context.getSetting(VOICE_INPUT_CHANNEL_MODE))
 
         state.modelManager.useGpu = useGpu
 
@@ -433,7 +438,8 @@ private class VoiceInputBottomBarWindow(
                 preferBluetoothMic = useBluetoothAudio,
                 requestAudioFocus = requestAudioFocus,
                 canExpandSpace = canExpandSpace,
-                useVADAutoStop = useVAD
+                useVADAutoStop = useVAD,
+                channelMode = channelMode
             ),
             groqApiKey = if(useGroq) groqKey else "",
             groqModel = groqModel,

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/VoiceInput.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/VoiceInput.kt
@@ -2,6 +2,7 @@ package org.futo.inputmethod.latin.uix.settings.pages
 
 import android.content.Intent
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
 import org.futo.inputmethod.latin.R
 import org.futo.inputmethod.latin.uix.AUDIO_FOCUS
 import org.futo.inputmethod.latin.uix.CAN_EXPAND_SPACE
@@ -17,11 +18,16 @@ import org.futo.inputmethod.latin.uix.GROQ_VOICE_API_KEY
 import org.futo.inputmethod.latin.uix.USE_GPU_OFFLOAD
 import org.futo.inputmethod.latin.uix.START_VOICE_ON_OPEN
 import org.futo.inputmethod.latin.uix.VOICE_INPUT_BOTTOM_BAR_MODE
+import org.futo.inputmethod.latin.uix.VOICE_INPUT_CHANNEL_MODE
 import org.futo.inputmethod.latin.uix.settings.NavigationItemStyle
+import org.futo.inputmethod.latin.uix.settings.SettingRadio
+import org.futo.inputmethod.latin.uix.settings.UserSetting
 import org.futo.inputmethod.latin.uix.settings.UserSettingsMenu
+import org.futo.inputmethod.latin.uix.settings.useDataStore
 import org.futo.inputmethod.latin.uix.settings.useDataStoreValue
 import org.futo.inputmethod.latin.uix.settings.userSettingNavigationItem
 import org.futo.inputmethod.latin.uix.settings.userSettingToggleDataStore
+import org.futo.voiceinput.shared.types.RecordingChannelMode
 
 private val visibilityCheckNotSystemVoiceInput = @Composable {
     useDataStoreValue(USE_SYSTEM_VOICE_INPUT) == false
@@ -63,6 +69,29 @@ val VoiceInputMenu = UserSettingsMenu(
             subtitle = R.string.voice_input_settings_use_bluetooth_mic_subtitle,
             setting = PREFER_BLUETOOTH
         ).copy(visibilityCheck = visibilityCheckNotSystemVoiceInput),
+
+        UserSetting(
+            name = R.string.voice_input_settings_audio_channel,
+            subtitle = R.string.voice_input_settings_audio_channel_subtitle
+        ) {
+            val channelMode = useDataStore(VOICE_INPUT_CHANNEL_MODE)
+            SettingRadio(
+                title = stringResource(R.string.voice_input_settings_audio_channel),
+                options = listOf(
+                    RecordingChannelMode.MONO.ordinal,
+                    RecordingChannelMode.CHANNEL_1.ordinal,
+                    RecordingChannelMode.CHANNEL_2.ordinal,
+                    RecordingChannelMode.TEST_CHANNELS.ordinal
+                ),
+                optionNames = listOf(
+                    stringResource(R.string.voice_input_settings_audio_channel_default),
+                    stringResource(R.string.voice_input_settings_audio_channel_1),
+                    stringResource(R.string.voice_input_settings_audio_channel_2),
+                    stringResource(R.string.voice_input_settings_audio_channel_test)
+                ),
+                setting = channelMode
+            )
+        }.copy(visibilityCheck = visibilityCheckNotSystemVoiceInput),
 
         userSettingToggleDataStore(
             title = R.string.voice_input_settings_audio_focus,

--- a/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/AudioRecognizer.kt
+++ b/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/AudioRecognizer.kt
@@ -38,6 +38,7 @@ import org.futo.voiceinput.shared.types.Language
 import org.futo.voiceinput.shared.types.MagnitudeState
 import org.futo.voiceinput.shared.types.ModelInferenceCallback
 import org.futo.voiceinput.shared.types.ModelLoader
+import org.futo.voiceinput.shared.types.RecordingChannelMode
 import org.futo.voiceinput.shared.ui.MicrophoneDeviceState
 import org.futo.voiceinput.shared.whisper.DecodingConfiguration
 import org.futo.voiceinput.shared.whisper.ModelManager
@@ -84,7 +85,8 @@ data class RecordingSettings(
     val preferBluetoothMic: Boolean,
     val requestAudioFocus: Boolean,
     val canExpandSpace: Boolean,
-    val useVADAutoStop: Boolean
+    val useVADAutoStop: Boolean,
+    val channelMode: RecordingChannelMode
 )
 
 data class AudioRecognizerSettings(
@@ -119,7 +121,8 @@ class AudioRecognizer(
     private val canExpandSpace = settings.recordingConfiguration.canExpandSpace
     private val useVAD = settings.recordingConfiguration.useVADAutoStop
 
-    private var floatSamples: FloatBuffer = FloatBuffer.allocate(16000 * 30)
+    private var floatSamplesPrimary: FloatBuffer = FloatBuffer.allocate(16000 * 30)
+    private var floatSamplesSecondary: FloatBuffer? = null
     private var recorderJob: Job? = null
     private var modelJob: Job? = null
     private var loadModelJob: Job? = null
@@ -127,6 +130,7 @@ class AudioRecognizer(
     private var focusRequest: AudioFocusRequest? = null
 
     private var communicationDevice = "unknown"
+    private var activeChannelMode = settings.recordingConfiguration.channelMode
 
     private fun focusAudio() {
         unfocusAudio()
@@ -241,7 +245,8 @@ class AudioRecognizer(
         modelJob?.cancel()
         isRecording = false
 
-        floatSamples = FloatBuffer.allocate(16000 * 30)
+        activeChannelMode = settings.recordingConfiguration.channelMode
+        configureSampleBuffers(activeChannelMode)
 
         modelRunner.cancelAll()
 
@@ -293,13 +298,40 @@ class AudioRecognizer(
 
     @Throws(SecurityException::class)
     private fun createAudioRecorder(): AudioRecord {
+        val desiredChannelConfig = if (settings.recordingConfiguration.channelMode.requiresStereo()) {
+            AudioFormat.CHANNEL_IN_STEREO
+        } else {
+            AudioFormat.CHANNEL_IN_MONO
+        }
+        val desiredChannelCount = if (desiredChannelConfig == AudioFormat.CHANNEL_IN_STEREO) 2 else 1
+
         val recorder = AudioRecord(
             MediaRecorder.AudioSource.VOICE_RECOGNITION,
             16000,
-            AudioFormat.CHANNEL_IN_MONO,
+            desiredChannelConfig,
             AudioFormat.ENCODING_PCM_16BIT,
-            16000 * 2 * 5
+            16000 * 2 * desiredChannelCount * 5
         )
+
+        if (recorder.state != AudioRecord.STATE_INITIALIZED && desiredChannelConfig == AudioFormat.CHANNEL_IN_STEREO) {
+            recorder.release()
+            activeChannelMode = RecordingChannelMode.MONO
+            configureSampleBuffers(activeChannelMode)
+            return AudioRecord(
+                MediaRecorder.AudioSource.VOICE_RECOGNITION,
+                16000,
+                AudioFormat.CHANNEL_IN_MONO,
+                AudioFormat.ENCODING_PCM_16BIT,
+                16000 * 2 * 5
+            )
+        }
+
+        activeChannelMode = if (desiredChannelConfig == AudioFormat.CHANNEL_IN_STEREO) {
+            settings.recordingConfiguration.channelMode
+        } else {
+            RecordingChannelMode.MONO
+        }
+        configureSampleBuffers(activeChannelMode)
 
         this.recorder = recorder
 
@@ -317,13 +349,35 @@ class AudioRecognizer(
     private fun expandSpaceIfAllowed(): Boolean {
         if(canExpandSpace) {
             // Allocate an extra 30 seconds
-            val newSampleBuffer = FloatBuffer.allocate(floatSamples.capacity() + 16000 * 30)
-            //Log.d("AudioRecognizer", "Allocating extra space: ${floatSamples.capacity() / 16000} -> ${newSampleBuffer.capacity() / 16000}")
-            newSampleBuffer.put(floatSamples.array(), 0, floatSamples.capacity() - floatSamples.remaining())
-            floatSamples = newSampleBuffer
+            val extraSamples = 16000 * 30
+            val newSampleBuffer = FloatBuffer.allocate(floatSamplesPrimary.capacity() + extraSamples)
+            newSampleBuffer.put(
+                floatSamplesPrimary.array(),
+                0,
+                floatSamplesPrimary.capacity() - floatSamplesPrimary.remaining()
+            )
+            floatSamplesPrimary = newSampleBuffer
+
+            floatSamplesSecondary = floatSamplesSecondary?.let { existing ->
+                val expanded = FloatBuffer.allocate(existing.capacity() + extraSamples)
+                expanded.put(existing.array(), 0, existing.capacity() - existing.remaining())
+                expanded
+            }
             return true
         }
         return false
+    }
+
+    private fun configureSampleBuffers(channelMode: RecordingChannelMode) {
+        floatSamplesPrimary = FloatBuffer.allocate(16000 * 30)
+        floatSamplesSecondary = if (channelMode.isTestMode()) FloatBuffer.allocate(16000 * 30) else null
+    }
+
+    private fun appendFloatSamples(target: FloatBuffer, samples: ShortArray, length: Int) {
+        val floats = FloatArray(length) { index ->
+            samples[index].toFloat() / Short.MAX_VALUE.toFloat()
+        }
+        target.put(floats)
     }
 
     private suspend fun recordingJob(recorder: AudioRecord, vad: VadModel?) {
@@ -343,15 +397,26 @@ class AudioRecognizer(
         var numConsecutiveNonSpeech = 0
         var numConsecutiveSpeech = 0
 
-        val samples = ShortArray(1600)
+        val channelCount = if (activeChannelMode.requiresStereo()) 2 else 1
+        val samples = ShortArray(1600 * channelCount)
+        val channelOneSamples = ShortArray(1600)
+        val channelTwoSamples = if (activeChannelMode.isTestMode() || activeChannelMode == RecordingChannelMode.CHANNEL_2) {
+            ShortArray(1600)
+        } else {
+            null
+        }
 
         while (isRecording) {
             yield()
-            val nRead = recorder.read(samples, 0, 1600, AudioRecord.READ_BLOCKING)
+            val nRead = recorder.read(samples, 0, samples.size, AudioRecord.READ_BLOCKING)
             if (nRead <= 0) break
             yield()
 
-            var isRunningOutOfSpace = (floatSamples.remaining() < nRead.coerceAtLeast(1600)) && !expandSpaceIfAllowed()
+            val framesRead = nRead / channelCount
+            val requiredSamples = framesRead.coerceAtLeast(1600)
+            val isOutOfPrimarySpace = floatSamplesPrimary.remaining() < requiredSamples
+            val isOutOfSecondarySpace = floatSamplesSecondary?.remaining()?.let { it < requiredSamples } ?: false
+            var isRunningOutOfSpace = (isOutOfPrimarySpace || isOutOfSecondarySpace) && !expandSpaceIfAllowed()
 
             val hasNotTalkedRecently = hasTalked && (numConsecutiveNonSpeech > 66) && useVAD
             if (isRunningOutOfSpace || hasNotTalkedRecently) {
@@ -362,9 +427,30 @@ class AudioRecognizer(
                 return
             }
 
+            val selectedSamples: ShortArray
+            val selectedLength: Int
+
+            if (channelCount == 1) {
+                selectedSamples = samples
+                selectedLength = nRead
+            } else {
+                val frames = framesRead
+                for (i in 0 until frames) {
+                    val baseIndex = i * channelCount
+                    channelOneSamples[i] = samples[baseIndex]
+                    channelTwoSamples?.let { it[i] = samples[baseIndex + 1] }
+                }
+                selectedLength = frames
+                selectedSamples = if (activeChannelMode == RecordingChannelMode.CHANNEL_2) {
+                    channelTwoSamples ?: channelOneSamples
+                } else {
+                    channelOneSamples
+                }
+            }
+
             // Run VAD
             if(useVAD && vad != null) {
-                var remainingSamples = nRead
+                var remainingSamples = selectedLength
                 var offset = 0
                 while (remainingSamples > 0) {
                     if (!vadSampleBuffer.hasRemaining()) {
@@ -384,7 +470,7 @@ class AudioRecognizer(
                     val samplesToRead = min(min(remainingSamples, 480), vadSampleBuffer.remaining())
                     for (i in 0 until samplesToRead) {
                         vadSampleBuffer.put(
-                            samples[offset]
+                            selectedSamples[offset]
                         )
                         offset += 1
                         remainingSamples -= 1
@@ -392,8 +478,11 @@ class AudioRecognizer(
                 }
             }
 
-            floatSamples.put(samples.sliceArray(0 until nRead).map { it.toFloat() / Short.MAX_VALUE.toFloat() }.toFloatArray())
-            if(floatSamples.position() >= 16000 * 60) {
+            appendFloatSamples(floatSamplesPrimary, selectedSamples, selectedLength)
+            if (activeChannelMode.isTestMode() && channelTwoSamples != null) {
+                appendFloatSamples(floatSamplesSecondary!!, channelTwoSamples, selectedLength)
+            }
+            if(floatSamplesPrimary.position() >= 16000 * 60) {
                 yield()
                 withContext(Dispatchers.Main) { finish() }
                 return
@@ -401,13 +490,17 @@ class AudioRecognizer(
 
             // Don't set hasTalked if the start sound may still be playing, otherwise on some
             // devices the rms just explodes and `hasTalked` is always true
-            val startSoundPassed = (floatSamples.position() > 16000 * 0.6)
+            val startSoundPassed = (floatSamplesPrimary.position() > 16000 * 0.6)
             if (!startSoundPassed) {
                 numConsecutiveSpeech = 0
                 numConsecutiveNonSpeech = 0
             }
 
-            val rms = sqrt(samples.sumOf { (it.toFloat() / Short.MAX_VALUE.toFloat()).pow(2).toDouble() } / samples.size).toFloat()
+            val rms = sqrt(
+                selectedSamples.take(selectedLength)
+                    .sumOf { (it.toFloat() / Short.MAX_VALUE.toFloat()).pow(2).toDouble() } /
+                    selectedLength.coerceAtLeast(1)
+            ).toFloat()
 
             if (startSoundPassed && ((rms > 0.01) || (numConsecutiveSpeech > 8))) {
                 hasTalked = true
@@ -419,7 +512,7 @@ class AudioRecognizer(
             }
 
             // Check if mic is blocked
-            val blockCheckTimePassed = (floatSamples.position() > 2 * 16000) // two seconds
+            val blockCheckTimePassed = (floatSamplesPrimary.position() > 2 * 16000) // two seconds
             if (!anyNoiseAtAll && canMicBeBlocked && blockCheckTimePassed) {
                 isMicBlocked = true
             }
@@ -444,18 +537,40 @@ class AudioRecognizer(
             while (true) {
                 yield()
                 val nRead2 = recorder.read(
-                    samples, 0, 1600, AudioRecord.READ_NON_BLOCKING
+                    samples, 0, samples.size, AudioRecord.READ_NON_BLOCKING
                 )
                 if (nRead2 > 0) {
-                    if (floatSamples.remaining() < nRead2 && !expandSpaceIfAllowed()) {
+                    val framesRead2 = nRead2 / channelCount
+                    val requiredSamples2 = framesRead2.coerceAtLeast(1600)
+                    val isPrimaryOutOfSpace = floatSamplesPrimary.remaining() < requiredSamples2
+                    val isSecondaryOutOfSpace = floatSamplesSecondary?.remaining()?.let { it < requiredSamples2 } ?: false
+                    if ((isPrimaryOutOfSpace || isSecondaryOutOfSpace) && !expandSpaceIfAllowed()) {
                         yield()
                         withContext(Dispatchers.Main) {
                             finish()
                         }
                         break
                     }
-                    floatSamples.put(samples.sliceArray(0 until nRead2).map { it.toFloat() / Short.MAX_VALUE.toFloat() }.toFloatArray())
-                    if(floatSamples.position() >= 16000 * 60) {
+                    if (channelCount == 1) {
+                        appendFloatSamples(floatSamplesPrimary, samples, nRead2)
+                    } else {
+                        val frames = framesRead2
+                        for (i in 0 until frames) {
+                            val baseIndex = i * channelCount
+                            channelOneSamples[i] = samples[baseIndex]
+                            channelTwoSamples?.let { it[i] = samples[baseIndex + 1] }
+                        }
+                        val target = if (activeChannelMode == RecordingChannelMode.CHANNEL_2) {
+                            channelTwoSamples ?: channelOneSamples
+                        } else {
+                            channelOneSamples
+                        }
+                        appendFloatSamples(floatSamplesPrimary, target, frames)
+                        if (activeChannelMode.isTestMode() && channelTwoSamples != null) {
+                            appendFloatSamples(floatSamplesSecondary!!, channelTwoSamples, frames)
+                        }
+                    }
+                    if(floatSamplesPrimary.position() >= 16000 * 60) {
                         yield()
                         withContext(Dispatchers.Main) { finish() }
                         break
@@ -585,62 +700,70 @@ class AudioRecognizer(
 
         if (currentSessionId != sessionId.get()) return
 
-        val floatArray = floatSamples.array().sliceArray(0 until floatSamples.position())
-
-        // First try Groq if configured
-        if (settings.groqApiKey.isNotBlank()) {
-            try {
-                val groqResult = withContext(Dispatchers.IO) {
-                    org.futo.voiceinput.shared.groq.GroqWhisperApi.transcribe(
-                        floatArray, 
-                        settings.groqApiKey, 
-                        settings.groqModel,
-                        settings.groqSystemPrompt.ifBlank { null }
-                    )
-                }
-                
-                if (!groqResult.isNullOrBlank()) {
-                    // Groq succeeded, return its result
-                    if (currentSessionId != sessionId.get()) return
-                    yield()
-                    lifecycleScope.launch {
-                        withContext(Dispatchers.Main) {
-                            if (currentSessionId != sessionId.get()) return@withContext
-                            listener.finished(normalizeTranscription(groqResult))
-                        }
+        suspend fun transcribe(floatArray: FloatArray): String {
+            // First try Groq if configured
+            if (settings.groqApiKey.isNotBlank()) {
+                try {
+                    val groqResult = withContext(Dispatchers.IO) {
+                        org.futo.voiceinput.shared.groq.GroqWhisperApi.transcribe(
+                            floatArray,
+                            settings.groqApiKey,
+                            settings.groqModel,
+                            settings.groqSystemPrompt.ifBlank { null }
+                        )
                     }
-                    return
-                }
-                // If we get here, Groq failed, fall through to local model
-            } catch (e: Exception) {
-                // Groq failed, fall through to local model
-                println("Groq transcription failed: ${e.message}")
-            }
-        }
 
-        // Either Groq is not configured or it failed, use local model
-        val outputText = try {
-            modelRunner.run(
+                    if (!groqResult.isNullOrBlank()) {
+                        return groqResult
+                    }
+                } catch (e: Exception) {
+                    println("Groq transcription failed: ${e.message}")
+                }
+            }
+
+            // Either Groq is not configured or it failed, use local model
+            return modelRunner.run(
                 floatArray,
                 settings.modelRunConfiguration,
                 settings.decodingConfiguration,
                 runnerCallback
             ).trim()
-        } catch(e: InferenceCancelledException) {
+        }
+
+        val primaryArray = floatSamplesPrimary.array().sliceArray(0 until floatSamplesPrimary.position())
+        val primaryText = try {
+            transcribe(primaryArray)
+        } catch (e: InferenceCancelledException) {
             yield()
             return
         }
 
         if (currentSessionId != sessionId.get()) return
 
-        val text = if (isBlankResult(outputText)) "" else outputText
+        val finalText = if (activeChannelMode.isTestMode()) {
+            val secondaryArray = floatSamplesSecondary?.array()
+                ?.sliceArray(0 until (floatSamplesSecondary?.position() ?: 0))
+                ?: FloatArray(0)
+            val secondaryText = try {
+                transcribe(secondaryArray)
+            } catch (e: InferenceCancelledException) {
+                yield()
+                return
+            }
+            val normalizedPrimary = if (isBlankResult(primaryText)) "" else normalizeTranscription(primaryText)
+            val normalizedSecondary = if (isBlankResult(secondaryText)) "" else normalizeTranscription(secondaryText)
+            "Channel 1: $normalizedPrimary\nChannel 2: $normalizedSecondary"
+        } else {
+            val text = if (isBlankResult(primaryText)) "" else primaryText
+            normalizeTranscription(text)
+        }
 
         yield()
         lifecycleScope.launch {
             withContext(Dispatchers.Main) {
                 if (currentSessionId != sessionId.get()) return@withContext
                 yield()
-                listener.finished(normalizeTranscription(text))
+                listener.finished(finalText)
             }
         }
     }

--- a/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/types/RecordingChannelMode.kt
+++ b/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/types/RecordingChannelMode.kt
@@ -1,0 +1,22 @@
+package org.futo.voiceinput.shared.types
+
+enum class RecordingChannelMode {
+    MONO,
+    CHANNEL_1,
+    CHANNEL_2,
+    TEST_CHANNELS;
+
+    fun requiresStereo(): Boolean {
+        return this != MONO
+    }
+
+    fun isTestMode(): Boolean {
+        return this == TEST_CHANNELS
+    }
+
+    companion object {
+        fun fromSetting(value: Int): RecordingChannelMode {
+            return entries.getOrElse(value) { MONO }
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide an option in voice input settings to select which device channel to record (mono, channel 1, channel 2) and a test mode to capture both channels simultaneously for transcript comparison. 
- Enable easier debugging and evaluation of transcripts coming from different physical channels or from a stereo-capable input device.

### Description

- Introduce a new enum `RecordingChannelMode` with modes `MONO`, `CHANNEL_1`, `CHANNEL_2`, and `TEST_CHANNELS` to represent recording channel selection and helper methods to query its behavior (`requiresStereo`, `isTestMode`).
- Add a new settings key `VOICE_INPUT_CHANNEL_MODE` and UI strings for audio channel options, and expose a radio setting in the Voice Input settings screen to pick the channel mode.
- Extend `RecordingSettings` and `AudioRecognizer` to accept the channel mode, attempt to create a stereo `AudioRecord` when required, and fall back to mono if stereo initialization fails.
- Capture and split stereo frames into separate buffers, transcribe the primary channel normally, and in test mode transcribe both channels and return labeled results (`Channel 1: ...\nChannel 2: ...`).

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e32c05518832786a84face67a319d)