### PR TITLE
Add local voice system prompt setting and expose in Languages & Models

### DIFF
--- a/java/res/values/strings-uix.xml
+++ b/java/res/values/strings-uix.xml
@@ -359,6 +359,8 @@
     <string name="language_settings_remove_language_cancel_button">Cancel</string>
 
     <string name="language_settings_other_options">Other options</string>
+    <string name="language_settings_local_model_system_prompt">Local model system prompt</string>
+    <string name="language_settings_local_model_system_prompt_placeholder">Optional context to guide local transcription (e.g., names, jargon)</string>
     <string name="language_settings_import_resource_from_file">Import resource file</string>
     <string name="language_settings_explore_voice_input_models_online">Explore voice input models</string>
     <string name="language_settings_explore_dictionaries_online">Explore dictionaries</string>

--- a/java/src/org/futo/inputmethod/latin/uix/VoiceInputSettingKeys.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/VoiceInputSettingKeys.kt
@@ -85,6 +85,11 @@ val GROQ_VOICE_SYSTEM_PROMPT = SettingsKey(
     default = ""
 )
 
+val LOCAL_VOICE_SYSTEM_PROMPT = SettingsKey(
+    key = stringPreferencesKey("local_voice_system_prompt"),
+    default = ""
+)
+
 val USE_GPU_OFFLOAD = SettingsKey(
     key = booleanPreferencesKey("use_gpu_offload"),
     default = false

--- a/java/src/org/futo/inputmethod/latin/uix/actions/VoiceInputAction.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/VoiceInputAction.kt
@@ -86,6 +86,7 @@ import org.futo.inputmethod.latin.uix.USE_GROQ_WHISPER
 import org.futo.inputmethod.latin.uix.GROQ_VOICE_API_KEY
 import org.futo.inputmethod.latin.uix.GROQ_VOICE_MODEL
 import org.futo.inputmethod.latin.uix.GROQ_VOICE_SYSTEM_PROMPT
+import org.futo.inputmethod.latin.uix.LOCAL_VOICE_SYSTEM_PROMPT
 import org.futo.inputmethod.latin.uix.USE_GPU_OFFLOAD
 import org.futo.inputmethod.latin.uix.VOICE_INPUT_BOTTOM_BAR_MODE
 import org.futo.inputmethod.latin.uix.LocalKeyboardScheme
@@ -183,6 +184,7 @@ private class VoiceInputActionWindow(
         val groqModel = context.getSetting(GROQ_VOICE_MODEL)
         val useGpu = context.getSetting(USE_GPU_OFFLOAD)
         val groqSystemPrompt = context.getSetting(GROQ_VOICE_SYSTEM_PROMPT)
+        val localSystemPrompt = context.getSetting(LOCAL_VOICE_SYSTEM_PROMPT)
 
         state.modelManager.useGpu = useGpu
 
@@ -208,7 +210,7 @@ private class VoiceInputActionWindow(
                 glossary = glossary,
                 languages = allowedLanguages,
                 suppressSymbols = disallowSymbols,
-                systemPrompt = groqSystemPrompt
+                systemPrompt = localSystemPrompt
             ),
             recordingConfiguration = RecordingSettings(
                 preferBluetoothMic = useBluetoothAudio,
@@ -406,6 +408,7 @@ private class VoiceInputBottomBarWindow(
         val groqModel = context.getSetting(GROQ_VOICE_MODEL)
         val useGpu = context.getSetting(USE_GPU_OFFLOAD)
         val groqSystemPrompt = context.getSetting(GROQ_VOICE_SYSTEM_PROMPT)
+        val localSystemPrompt = context.getSetting(LOCAL_VOICE_SYSTEM_PROMPT)
 
         state.modelManager.useGpu = useGpu
 
@@ -427,7 +430,7 @@ private class VoiceInputBottomBarWindow(
                 glossary = state.userDictionaryObserver.getWords(locales).map { it.word },
                 languages = allowedLanguages,
                 suppressSymbols = disallowSymbols,
-                systemPrompt = groqSystemPrompt
+                systemPrompt = localSystemPrompt
             ),
             recordingConfiguration = RecordingSettings(
                 preferBluetoothMic = useBluetoothAudio,

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/Languages.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/Languages.kt
@@ -53,6 +53,7 @@ import org.futo.inputmethod.latin.R
 import org.futo.inputmethod.latin.Subtypes
 import org.futo.inputmethod.latin.SubtypesSetting
 import org.futo.inputmethod.latin.uix.FileKind
+import org.futo.inputmethod.latin.uix.LOCAL_VOICE_SYSTEM_PROMPT
 import org.futo.inputmethod.latin.uix.ResourceHelper
 import org.futo.inputmethod.latin.uix.getSetting
 import org.futo.inputmethod.latin.uix.icon
@@ -60,11 +61,13 @@ import org.futo.inputmethod.latin.uix.kindTitle
 import org.futo.inputmethod.latin.uix.namePreferenceKeyFor
 import org.futo.inputmethod.latin.uix.settings.NavigationItemStyle
 import org.futo.inputmethod.latin.uix.settings.ScreenTitle
+import org.futo.inputmethod.latin.uix.settings.SettingTextField
 import org.futo.inputmethod.latin.uix.settings.Tip
 import org.futo.inputmethod.latin.uix.settings.UserSettingsMenu
 import org.futo.inputmethod.latin.uix.settings.pages.modelmanager.openModelImporter
 import org.futo.inputmethod.latin.uix.settings.useDataStore
 import org.futo.inputmethod.latin.uix.settings.useDataStoreValue
+import org.futo.inputmethod.latin.uix.settings.userSettingDecorationOnly
 import org.futo.inputmethod.latin.uix.settings.userSettingNavigationItem
 import org.futo.inputmethod.latin.uix.theme.Typography
 import org.futo.inputmethod.latin.uix.theme.UixThemeWrapper
@@ -508,6 +511,13 @@ val LanguageSettingsTop = listOf(
     )
 )
 val LanguageSettingsBottom = listOf(
+    userSettingDecorationOnly {
+        SettingTextField(
+            title = stringResource(R.string.language_settings_local_model_system_prompt),
+            placeholder = stringResource(R.string.language_settings_local_model_system_prompt_placeholder),
+            field = LOCAL_VOICE_SYSTEM_PROMPT
+        )
+    },
     userSettingNavigationItem(
         title = R.string.language_settings_import_resource_from_file,
         style = NavigationItemStyle.Misc,


### PR DESCRIPTION
### Motivation

- Provide a separate system prompt for local (on-device) voice models so that the Groq system prompt remains unchanged for remote Groq usage. 
- Allow users to edit the local model system prompt from the Languages & Models settings screen to guide local transcription behavior.

### Description

- Added a new settings key `LOCAL_VOICE_SYSTEM_PROMPT` in `VoiceInputSettingKeys` to store the local model system prompt.
- Wired the new `LOCAL_VOICE_SYSTEM_PROMPT` into local voice decoding by reading it in `VoiceInputAction` and passing it to the `DecodingConfiguration.systemPrompt` for both full and bottom-bar voice input flows.
- Exposed a text field for the local system prompt in the Languages & Models screen by updating `Languages.kt` to include a `SettingTextField` bound to `LOCAL_VOICE_SYSTEM_PROMPT` and creating a `userSettingDecorationOnly` entry for it.
- Added two new string resources (`language_settings_local_model_system_prompt` and `language_settings_local_model_system_prompt_placeholder`) to `java/res/values/strings-uix.xml` for the UI.

### Testing

- No automated tests were executed for this change.
- The changes were committed locally (4 files updated) and are ready for review and integration tests or build verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e4855b6f48327ad881f0113aa6c08)