### PR TITLE
Add two‑pass transcription option for Groq and local voice input

### DIFF
--- a/java/res/values/strings-uix.xml
+++ b/java/res/values/strings-uix.xml
@@ -361,6 +361,8 @@
     <string name="language_settings_other_options">Other options</string>
     <string name="language_settings_local_model_system_prompt">Local model system prompt</string>
     <string name="language_settings_local_model_system_prompt_placeholder">Optional context to guide local transcription (e.g., names, jargon)</string>
+    <string name="language_settings_local_model_two_pass_title">Two-pass transcription</string>
+    <string name="language_settings_local_model_two_pass_subtitle">Run a second pass using the first result as context</string>
     <string name="language_settings_import_resource_from_file">Import resource file</string>
     <string name="language_settings_explore_voice_input_models_online">Explore voice input models</string>
     <string name="language_settings_explore_dictionaries_online">Explore dictionaries</string>
@@ -593,6 +595,8 @@
     <string name="groq_voice_settings_model">Model</string>
     <string name="groq_voice_settings_system_prompt">System prompt</string>
     <string name="groq_voice_settings_system_prompt_placeholder">Optional context to guide transcription (e.g., names, jargon)</string>
+    <string name="groq_voice_settings_two_pass_title">Two-pass transcription</string>
+    <string name="groq_voice_settings_two_pass_subtitle">Run a second pass using the first result as context</string>
     <string name="groq_settings_testing">Testing…</string>
     <string name="groq_settings_test">Test connection</string>
     <string name="groq_settings_success">Test successful!</string>

--- a/java/src/org/futo/inputmethod/latin/uix/VoiceInputSettingKeys.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/VoiceInputSettingKeys.kt
@@ -90,9 +90,19 @@ val GROQ_VOICE_SYSTEM_PROMPT = SettingsKey(
     default = ""
 )
 
+val GROQ_VOICE_TWO_PASS = SettingsKey(
+    key = booleanPreferencesKey("groq_voice_two_pass"),
+    default = false
+)
+
 val LOCAL_VOICE_SYSTEM_PROMPT = SettingsKey(
     key = stringPreferencesKey("local_voice_system_prompt"),
     default = ""
+)
+
+val LOCAL_VOICE_TWO_PASS = SettingsKey(
+    key = booleanPreferencesKey("local_voice_two_pass"),
+    default = false
 )
 
 val USE_GPU_OFFLOAD = SettingsKey(

--- a/java/src/org/futo/inputmethod/latin/uix/actions/VoiceInputAction.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/VoiceInputAction.kt
@@ -86,7 +86,9 @@ import org.futo.inputmethod.latin.uix.USE_GROQ_WHISPER
 import org.futo.inputmethod.latin.uix.GROQ_VOICE_API_KEY
 import org.futo.inputmethod.latin.uix.GROQ_VOICE_MODEL
 import org.futo.inputmethod.latin.uix.GROQ_VOICE_SYSTEM_PROMPT
+import org.futo.inputmethod.latin.uix.GROQ_VOICE_TWO_PASS
 import org.futo.inputmethod.latin.uix.LOCAL_VOICE_SYSTEM_PROMPT
+import org.futo.inputmethod.latin.uix.LOCAL_VOICE_TWO_PASS
 import org.futo.inputmethod.latin.uix.USE_GPU_OFFLOAD
 import org.futo.inputmethod.latin.uix.VOICE_INPUT_BOTTOM_BAR_MODE
 import org.futo.inputmethod.latin.uix.VOICE_INPUT_CHANNEL_MODE
@@ -188,7 +190,9 @@ private class VoiceInputActionWindow(
         val groqModel = context.getSetting(GROQ_VOICE_MODEL)
         val useGpu = context.getSetting(USE_GPU_OFFLOAD)
         val groqSystemPrompt = context.getSetting(GROQ_VOICE_SYSTEM_PROMPT)
+        val groqTwoPass = context.getSetting(GROQ_VOICE_TWO_PASS)
         val localSystemPrompt = context.getSetting(LOCAL_VOICE_SYSTEM_PROMPT)
+        val localTwoPass = context.getSetting(LOCAL_VOICE_TWO_PASS)
         val channelMode = RecordingChannelMode.fromSetting(context.getSetting(VOICE_INPUT_CHANNEL_MODE))
 
         state.modelManager.useGpu = useGpu
@@ -228,6 +232,8 @@ private class VoiceInputActionWindow(
             groqApiKey = if(useGroq) groqKey else "",
             groqModel = groqModel,
             groqSystemPrompt = groqSystemPrompt,
+            groqTwoPass = groqTwoPass,
+            localTwoPass = localTwoPass,
             useGpuOffload = useGpu
         )
     }
@@ -416,7 +422,9 @@ private class VoiceInputBottomBarWindow(
         val groqModel = context.getSetting(GROQ_VOICE_MODEL)
         val useGpu = context.getSetting(USE_GPU_OFFLOAD)
         val groqSystemPrompt = context.getSetting(GROQ_VOICE_SYSTEM_PROMPT)
+        val groqTwoPass = context.getSetting(GROQ_VOICE_TWO_PASS)
         val localSystemPrompt = context.getSetting(LOCAL_VOICE_SYSTEM_PROMPT)
+        val localTwoPass = context.getSetting(LOCAL_VOICE_TWO_PASS)
         val channelMode = RecordingChannelMode.fromSetting(context.getSetting(VOICE_INPUT_CHANNEL_MODE))
         val prebufferSeconds = context.getSetting(VOICE_INPUT_PREBUFFER_SECONDS)
 
@@ -453,6 +461,8 @@ private class VoiceInputBottomBarWindow(
             groqApiKey = if(useGroq) groqKey else "",
             groqModel = groqModel,
             groqSystemPrompt = groqSystemPrompt,
+            groqTwoPass = groqTwoPass,
+            localTwoPass = localTwoPass,
             useGpuOffload = useGpu
         )
     }

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/GroqConfigWhisper.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/GroqConfigWhisper.kt
@@ -14,10 +14,12 @@ import org.futo.inputmethod.latin.R
 import org.futo.inputmethod.latin.uix.GROQ_VOICE_API_KEY
 import org.futo.inputmethod.latin.uix.GROQ_VOICE_MODEL
 import org.futo.inputmethod.latin.uix.GROQ_VOICE_SYSTEM_PROMPT
+import org.futo.inputmethod.latin.uix.GROQ_VOICE_TWO_PASS
 import org.futo.inputmethod.latin.uix.settings.ScrollableList
 import org.futo.inputmethod.latin.uix.settings.ScreenTitle
 import org.futo.inputmethod.latin.uix.settings.SettingItem
 import org.futo.inputmethod.latin.uix.settings.SettingTextField
+import org.futo.inputmethod.latin.uix.settings.SettingToggleDataStore
 import org.futo.inputmethod.latin.uix.settings.DropDownPickerSettingItem
 import org.futo.inputmethod.latin.uix.settings.useDataStore
 import org.futo.voiceinput.shared.groq.GroqWhisperApi
@@ -82,6 +84,12 @@ fun GroqWhisperConfigScreen(navController: NavHostController = rememberNavContro
             title = stringResource(R.string.groq_voice_settings_system_prompt),
             placeholder = stringResource(R.string.groq_voice_settings_system_prompt_placeholder),
             field = GROQ_VOICE_SYSTEM_PROMPT
+        )
+
+        SettingToggleDataStore(
+            title = stringResource(R.string.groq_voice_settings_two_pass_title),
+            subtitle = stringResource(R.string.groq_voice_settings_two_pass_subtitle),
+            setting = GROQ_VOICE_TWO_PASS
         )
 
         // Models dropdown with loading and error states

--- a/java/src/org/futo/inputmethod/latin/uix/settings/pages/Languages.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/settings/pages/Languages.kt
@@ -54,6 +54,7 @@ import org.futo.inputmethod.latin.Subtypes
 import org.futo.inputmethod.latin.SubtypesSetting
 import org.futo.inputmethod.latin.uix.FileKind
 import org.futo.inputmethod.latin.uix.LOCAL_VOICE_SYSTEM_PROMPT
+import org.futo.inputmethod.latin.uix.LOCAL_VOICE_TWO_PASS
 import org.futo.inputmethod.latin.uix.ResourceHelper
 import org.futo.inputmethod.latin.uix.getSetting
 import org.futo.inputmethod.latin.uix.icon
@@ -62,6 +63,7 @@ import org.futo.inputmethod.latin.uix.namePreferenceKeyFor
 import org.futo.inputmethod.latin.uix.settings.NavigationItemStyle
 import org.futo.inputmethod.latin.uix.settings.ScreenTitle
 import org.futo.inputmethod.latin.uix.settings.SettingTextField
+import org.futo.inputmethod.latin.uix.settings.SettingToggleDataStore
 import org.futo.inputmethod.latin.uix.settings.Tip
 import org.futo.inputmethod.latin.uix.settings.UserSettingsMenu
 import org.futo.inputmethod.latin.uix.settings.pages.modelmanager.openModelImporter
@@ -516,6 +518,13 @@ val LanguageSettingsBottom = listOf(
             title = stringResource(R.string.language_settings_local_model_system_prompt),
             placeholder = stringResource(R.string.language_settings_local_model_system_prompt_placeholder),
             field = LOCAL_VOICE_SYSTEM_PROMPT
+        )
+    },
+    userSettingDecorationOnly {
+        SettingToggleDataStore(
+            title = stringResource(R.string.language_settings_local_model_two_pass_title),
+            subtitle = stringResource(R.string.language_settings_local_model_two_pass_subtitle),
+            setting = LOCAL_VOICE_TWO_PASS
         )
     },
     userSettingNavigationItem(

--- a/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/AudioRecognizer.kt
+++ b/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/AudioRecognizer.kt
@@ -100,6 +100,8 @@ data class AudioRecognizerSettings(
     val groqApiKey: String,
     val groqModel: String,
     val groqSystemPrompt: String,
+    val groqTwoPass: Boolean,
+    val localTwoPass: Boolean,
     val useGpuOffload: Boolean
 )
 
@@ -812,6 +814,18 @@ class AudioRecognizer(
             }
         }
 
+        fun buildSecondPassPrompt(basePrompt: String, firstPass: String): String {
+            val trimmedFirst = firstPass.trim()
+            val trimmedBase = basePrompt.trim()
+            if (trimmedFirst.isBlank()) {
+                return trimmedBase
+            }
+            val contextPrompt = "First pass transcription:\n$trimmedFirst"
+            return listOf(trimmedBase, contextPrompt)
+                .filter { it.isNotBlank() }
+                .joinToString(separator = "\n\n")
+        }
+
         loadModelJob?.let {
             if (it.isActive) {
                 println("Model was not finished loading...")
@@ -835,13 +849,31 @@ class AudioRecognizer(
                     }
                     
                     if (!groqResult.isNullOrBlank()) {
-                        // Groq succeeded, return its result
-                        if (currentSessionId != sessionId.get()) return groqResult
-                        yield()
-                        lifecycleScope.launch {
-                            withContext(Dispatchers.Main) {
-                                if (currentSessionId != sessionId.get()) return@withContext
-                                listener.finished(normalizeTranscription(groqResult))
+                        if (settings.groqTwoPass) {
+                            val secondPassPrompt = buildSecondPassPrompt(
+                                settings.groqSystemPrompt,
+                                groqResult
+                            )
+                            val secondResult = withContext(Dispatchers.IO) {
+                                org.futo.voiceinput.shared.groq.GroqWhisperApi.transcribe(
+                                    floatArray,
+                                    settings.groqApiKey,
+                                    settings.groqModel,
+                                    secondPassPrompt.ifBlank { null }
+                                )
+                            }
+                            if (!secondResult.isNullOrBlank()) {
+                                return secondResult
+                            }
+                        } else {
+                            // Groq succeeded, return its result
+                            if (currentSessionId != sessionId.get()) return groqResult
+                            yield()
+                            lifecycleScope.launch {
+                                withContext(Dispatchers.Main) {
+                                    if (currentSessionId != sessionId.get()) return@withContext
+                                    listener.finished(normalizeTranscription(groqResult))
+                                }
                             }
                         }
                     }
@@ -855,12 +887,25 @@ class AudioRecognizer(
             }
 
             // Either Groq is not configured or it failed, use local model
-            return modelRunner.run(
+            val firstPassResult = modelRunner.run(
                 floatArray,
                 settings.modelRunConfiguration,
                 settings.decodingConfiguration,
                 runnerCallback
             ).trim()
+            if (settings.localTwoPass && firstPassResult.isNotBlank()) {
+                val secondPassPrompt = buildSecondPassPrompt(
+                    settings.decodingConfiguration.systemPrompt,
+                    firstPassResult
+                )
+                return modelRunner.run(
+                    floatArray,
+                    settings.modelRunConfiguration,
+                    settings.decodingConfiguration.copy(systemPrompt = secondPassPrompt),
+                    runnerCallback
+                ).trim()
+            }
+            return firstPassResult
         }
 
         val primaryArray = floatSamplesPrimary.array().sliceArray(0 until floatSamplesPrimary.position())

--- a/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/RecognizerView.kt
+++ b/voiceinput-shared/src/main/java/org/futo/voiceinput/shared/RecognizerView.kt
@@ -43,7 +43,9 @@ data class RecognizerViewSettings(
     val recordingConfiguration: RecordingSettings,
     val groqApiKey: String,
     val groqModel: String,
-    val groqSystemPrompt: String
+    val groqSystemPrompt: String,
+    val groqTwoPass: Boolean,
+    val localTwoPass: Boolean
 )
 
 private val VerboseAnnotations = hashMapOf(
@@ -265,6 +267,8 @@ class RecognizerView(
             groqApiKey = settings.groqApiKey,
             groqModel = settings.groqModel,
             groqSystemPrompt = settings.groqSystemPrompt,
+            groqTwoPass = settings.groqTwoPass,
+            localTwoPass = settings.localTwoPass,
             useGpuOffload = settings.useGpuOffload
         )
     )


### PR DESCRIPTION
### Motivation
- Provide an option to use the first run/transcription as context for a second run to improve accuracy for both remote (Groq) and local models.
- Expose two‑pass toggles in the Groq voice settings and per‑language local model settings so users can opt in.
- Wire user settings through the voice input stack so the recognizer can perform the optional second pass automatically.

### Description
- Added two new settings keys `GROQ_VOICE_TWO_PASS` and `LOCAL_VOICE_TWO_PASS` and corresponding UI toggles in `GroqConfigWhisper.kt` and `Languages.kt` plus string resources in `strings-uix.xml`.
- Extended `RecognizerViewSettings` and `AudioRecognizerSettings` to carry `groqTwoPass` and `localTwoPass`, and read those settings in `VoiceInputAction.kt` so they are passed into the recognizer.
- Implemented `buildSecondPassPrompt` and two‑pass behavior in `AudioRecognizer.kt` to optionally re‑run Groq (calling `GroqWhisperApi.transcribe` again with the first pass inserted as context) and re‑run the local `modelRunner` with the first pass added to the `systemPrompt`.

### Testing
- No automated tests were run in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698158cff5f083279c80e6308bac8fd2)