### PR TITLE
Fallback to local voice transcription when Groq is unreachable

### DIFF
--- a/java/res/values/strings-uix.xml
+++ b/java/res/values/strings-uix.xml
@@ -593,6 +593,7 @@
     <string name="groq_voice_settings_model">Model</string>
     <string name="groq_voice_settings_system_prompt">System prompt</string>
     <string name="groq_voice_settings_system_prompt_placeholder">Optional context to guide transcription (e.g., names, jargon)</string>
+    <string name="groq_voice_unavailable">Internet model not accessible. Using local transcription.</string>
     <string name="groq_settings_testing">Testing…</string>
     <string name="groq_settings_test">Test connection</string>
     <string name="groq_settings_success">Test successful!</string>

--- a/java/src/org/futo/inputmethod/latin/uix/actions/VoiceInputAction.kt
+++ b/java/src/org/futo/inputmethod/latin/uix/actions/VoiceInputAction.kt
@@ -65,6 +65,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
 import org.futo.inputmethod.latin.R
 import org.futo.inputmethod.latin.uix.AUDIO_FOCUS
@@ -93,6 +94,7 @@ import org.futo.inputmethod.latin.uix.VOICE_INPUT_CHANNEL_MODE
 import org.futo.inputmethod.latin.uix.VOICE_INPUT_PREBUFFER_SECONDS
 import org.futo.inputmethod.latin.uix.LocalKeyboardScheme
 import org.futo.inputmethod.latin.uix.getSetting
+import org.futo.inputmethod.latin.uix.showToastAboveKeyboard
 import org.futo.inputmethod.latin.uix.setSetting
 import org.futo.inputmethod.latin.uix.settings.SettingsActivity
 import org.futo.inputmethod.latin.uix.utils.ModelOutputSanitizer
@@ -104,6 +106,7 @@ import org.futo.voiceinput.shared.RecognizerViewListener
 import org.futo.voiceinput.shared.RecognizerViewSettings
 import org.futo.voiceinput.shared.RecordingSettings
 import org.futo.voiceinput.shared.SoundPlayer
+import org.futo.voiceinput.shared.groq.GroqWhisperApi
 import org.futo.voiceinput.shared.types.Language
 import org.futo.voiceinput.shared.types.ModelLoader
 import org.futo.voiceinput.shared.types.RecordingChannelMode
@@ -149,6 +152,23 @@ fun NoModelInstalled(locale: Locale) {
                 .align(Alignment.Center)
                 .padding(8.dp), textAlign = TextAlign.Center)
     }
+}
+
+private suspend fun ensureGroqAvailability(
+    context: Context,
+    settings: RecognizerViewSettings
+): RecognizerViewSettings {
+    if (settings.groqApiKey.isBlank()) return settings
+    val groqAvailable = withContext(Dispatchers.IO) {
+        GroqWhisperApi.test(settings.groqApiKey)
+    }
+    if (groqAvailable) return settings
+    withContext(Dispatchers.Main) {
+        context.showToastAboveKeyboard(
+            context.getString(R.string.groq_voice_unavailable)
+        )
+    }
+    return settings.copy(groqApiKey = "")
 }
 
 class VoiceInputPersistentState(val manager: KeyboardManagerForAction) : PersistentActionState {
@@ -237,7 +257,7 @@ private class VoiceInputActionWindow(
 
     private val initJob = manager.getLifecycleScope().launch {
         yield()
-        val settings = loadSettings()
+        val settings = ensureGroqAvailability(context, loadSettings())
 
         yield()
         val recognizerView = try {
@@ -462,7 +482,7 @@ private class VoiceInputBottomBarWindow(
 
     private val initJob = manager.getLifecycleScope().launch {
         yield()
-        val settings = loadSettings()
+        val settings = ensureGroqAvailability(context, loadSettings())
 
         yield()
         val recognizerView = try {


### PR DESCRIPTION
### Motivation
- Ensure the keyboard gracefully falls back to the local transcription model when the remote Groq Whisper API is not reachable despite the user opting to use Groq.
- Improve user experience by checking internet/Groq availability at voice-input startup and avoiding failed remote attempts during recording.
- Notify the user immediately that the internet/remote model is unavailable so they understand why the local model will be used.

### Description
- Added a suspend helper `ensureGroqAvailability(context, settings)` that calls `GroqWhisperApi.test(apiKey)` on `Dispatchers.IO` and returns a modified `RecognizerViewSettings` with `groqApiKey` cleared when Groq is unreachable.
- Show a toast above the keyboard using `showToastAboveKeyboard` with the new string `groq_voice_unavailable` when the Groq service cannot be contacted, so the user is informed that the local transcription will be used.
- Wire the availability check into both voice input initialization flows by replacing direct `loadSettings()` usage with `ensureGroqAvailability(context, loadSettings())` in `VoiceInputAction.kt` for the full window and bottom-bar window paths.
- Added the user-facing string resource `groq_voice_unavailable` to `java/res/values/strings-uix.xml` and updated imports to include `GroqWhisperApi` and the toast helper.

### Testing
- No automated tests were run for this change.
- The change is limited to initialization logic and string resources; please run the app and start voice input with Groq enabled to validate the fallback and toast behavior manually.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984bdc262b483279775ac40706a1961)