### PR TITLE
Prevent spacebar vertical cursor movement from leaving fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Check out the [FUTO Keyboard website](https://keyboard.futo.org/) for downloads 
 
 - T9 multi-tap now replaces the previous letter instead of inserting multiple characters and backspace obeys the "delete whole words" option.
 - Long‑press spacebar drag now moves the cursor vertically when sliding up or down.
+- Spacebar cursor dragging now stays within the text field instead of jumping focus past the top or bottom line.
 - Colored overlays appear above and below the keyboard when dragging on the spacebar to show vertical and horizontal cursor control.
 - Custom themes can set different background colors for each settings item icon.
 - Settings icons can also use custom background images loaded from files.

--- a/java/src/org/futo/inputmethod/latin/LatinIMELegacy.java
+++ b/java/src/org/futo/inputmethod/latin/LatinIMELegacy.java
@@ -47,6 +47,8 @@ import android.view.ViewGroup.LayoutParams;
 import android.view.Window;
 import android.view.WindowManager;
 import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.ExtractedText;
+import android.view.inputmethod.ExtractedTextRequest;
 import android.view.inputmethod.InputConnection;
 import android.view.inputmethod.InputMethodSubtype;
 
@@ -628,12 +630,49 @@ public class LatinIMELegacy implements KeyboardActionListener,
         setNeutralSuggestionStrip();
 
         final InputConnection ic = mInputMethodService.getCurrentInputConnection();
-        if (ic == null) return;
-        
+        if (ic == null || steps == 0) return;
+
+        final EditorInfo editorInfo = mInputMethodService.getCurrentInputEditorInfo();
+        if (editorInfo == null) {
+            return;
+        }
+        final boolean isMultiline = (editorInfo.inputType & InputType.TYPE_TEXT_FLAG_MULTI_LINE) != 0;
+        if (!isMultiline) {
+            return;
+        }
+
+        final ExtractedText extractedText = ic.getExtractedText(new ExtractedTextRequest(), 0);
+        if (extractedText != null && extractedText.text != null) {
+            final CharSequence text = extractedText.text;
+            final int cursor = Math.min(extractedText.selectionStart, extractedText.selectionEnd);
+            if (cursor >= 0 && cursor <= text.length()) {
+                final int requiredLines = Math.abs(steps);
+                int availableLines = 0;
+                if (steps < 0) {
+                    for (int i = cursor - 1; i >= 0; i--) {
+                        if (text.charAt(i) == '\n') {
+                            availableLines++;
+                            if (availableLines >= requiredLines) break;
+                        }
+                    }
+                } else {
+                    for (int i = cursor; i < text.length(); i++) {
+                        if (text.charAt(i) == '\n') {
+                            availableLines++;
+                            if (availableLines >= requiredLines) break;
+                        }
+                    }
+                }
+                if (availableLines < requiredLines) {
+                    return;
+                }
+            }
+        }
+
         ic.beginBatchEdit();
         final int keyCode = steps < 0 ? KeyEvent.KEYCODE_DPAD_UP : KeyEvent.KEYCODE_DPAD_DOWN;
         final long eventTime = android.os.SystemClock.uptimeMillis();
-        for(int i = 0; i < Math.abs(steps); i++) {
+        for (int i = 0; i < Math.abs(steps); i++) {
             ic.sendKeyEvent(new KeyEvent(eventTime, eventTime, KeyEvent.ACTION_DOWN, keyCode, 0));
             ic.sendKeyEvent(new KeyEvent(eventTime, eventTime, KeyEvent.ACTION_UP, keyCode, 0));
         }


### PR DESCRIPTION
### Motivation
- Spacebar long-press drag for vertical cursor movement could move the cursor past the top/bottom of single-line or short multi-line editors and leave the editable area.
- The change prevents surprising focus jumps and keeps cursor movement constrained to the text field.

### Description
- Gate `LatinIMELegacy.onMovePointerVertical` so it no-ops when `steps == 0`, when there is no `EditorInfo`, or when the target field is not multi-line by checking `InputType.TYPE_TEXT_FLAG_MULTI_LINE`.
- Query the editor content with `InputConnection.getExtractedText` and count newline boundaries to ensure there are enough lines in the requested direction before sending DPAD key events, avoiding movement past the first/last line.
- Preserve the original DPAD emulation behavior when movement is valid, and add `ExtractedText`/`ExtractedTextRequest` imports accordingly.
- Document the behavioral change in `README.md` (note that spacebar cursor dragging now stays within the text field).

### Testing
- No automated tests were run for this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a77a913ac832793cabae0c3497e2c)